### PR TITLE
Update ChangeLog

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 
-2018-06-08 v0.95
+2019-06-08 v0.95
 
 * The minimum supported version of Python is now 2.7.
 


### PR DESCRIPTION
Fix date (typo)

---

This was a bit confusing, momentarily, but then I saw the git history.

FWIW, PyPI says 0.95 was released on June **7** (2019), but I don't know what your timezone is — it may very well have been June 8 there. But I'm pretty certain it wasn't 2018 :)