### PR TITLE
fix argv check in jep environment

### DIFF
--- a/lmdb/__init__.py
+++ b/lmdb/__init__.py
@@ -29,8 +29,8 @@ import sys
 
 def _reading_docs():
     # Hack: disable speedups while testing or reading docstrings. Don't check
-    # for basename for embedded python - variable 'argv' does not exists there.
-    if not(hasattr(sys, 'argv')):
+    # for basename for embedded python - variable 'argv' does not exists there or is empty.
+    if not(hasattr(sys, 'argv')) or not sys.argv:
         return False
 
     basename = os.path.basename(sys.argv[0])


### PR DESCRIPTION
When using [JEP](https://github.com/ninia/jep), the `sys.argv` property exists but is empty. Raising index out of bounds for `sys.argv[0]`.

This fix should address that.