### PR TITLE
Fix lmdb.tool database encoding for Python3

### DIFF
--- a/lmdb/tool.py
+++ b/lmdb/tool.py
@@ -251,7 +251,7 @@ def cmd_copyfd(opts, args):
         die('"copyfd" command takes no arguments (see --help)')
 
     try:
-        fp = os.fdopen(opts.out_fd, 'w', 0)
+        os.fdopen(opts.out_fd, 'w', 0)
     except OSError:
         e = sys.exc_info()[1]
         die('Bad --out-fd %d: %s', opts.out_fd, e)
@@ -509,8 +509,8 @@ def cmd_rewrite(opts, args):
     dbs = []
     for arg in args:
         name = None if arg == ':main:' else arg
-        src_db = ENV.open_db(name)
-        dst_db = target_env.open_db(name)
+        src_db = ENV.open_db(_to_bytes(name))
+        dst_db = target_env.open_db(_to_bytes(name))
         dbs.append((arg, src_db, dst_db))
 
     if not dbs:
@@ -590,7 +590,7 @@ def _get_term_width(default=(80, 25)):
         s = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ, '1234')
         height, width = struct.unpack('hh', s)
         return width, height
-    except:
+    except Exception:
         return default
 
 
@@ -599,9 +599,9 @@ def _on_sigwinch(*args):
     _TERM_WIDTH, _TERM_HEIGHT = _get_term_width()
 
 
-def main():
+def main(argv):
     parser = make_parser()
-    opts, args = parser.parse_args()
+    opts, args = parser.parse_args(argv)
 
     if not args:
         die('Please specify a command (see --help)')
@@ -614,7 +614,7 @@ def main():
 
     if opts.db:
         global DB
-        DB = ENV.open_db(opts.db)
+        DB = ENV.open_db(_to_bytes(opts.db))
 
     if hasattr(signal, 'SIGWINCH'):  # Disable on win32.
         signal.signal(signal.SIGWINCH, _on_sigwinch)
@@ -628,4 +628,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv[1:])

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -29,6 +29,7 @@ import stat
 import sys
 import tempfile
 import traceback
+import unittest
 
 try:
     import __builtin__
@@ -49,6 +50,10 @@ def cleanup():
             traceback.print_exc()
 
 atexit.register(cleanup)
+
+class LmdbTest(unittest.TestCase):
+    def tearDown(self):
+        cleanup()
 
 
 def temp_dir(create=True):

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -24,14 +24,29 @@ from __future__ import absolute_import
 import unittest
 
 import lmdb
+import shlex
 import lmdb.tool
 
+import testlib
 
-class ToolTest(unittest.TestCase):
-    def test_ok(self):
-        # For now, simply ensure the module can be compiled (3.x compat).
-        pass
+def call_tool(cmdline):
+    return lmdb.tool.main(shlex.split(cmdline))
 
+class ToolTest(testlib.LmdbTest):
+    def test_cmd_get(self):
+        frompath, env = testlib.temp_env()
+        db = env.open_db(b'subdb')
+        with env.begin(write=True, db=db) as txn:
+            txn.put(b'foo', b'bar', db=db)
+        env.close()
+        call_tool('-d subdb get --env %s' % (frompath,))
+
+    def test_cmd_rewrite(self):
+        frompath, env = testlib.temp_env()
+        env.open_db(b'subdb')
+        env.close()
+        topath = testlib.temp_dir()
+        call_tool('rewrite -e %s -E %s subdb' % (frompath, topath))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -21,16 +21,21 @@
 #
 
 from __future__ import absolute_import
+
+import sys
+import shlex
 import unittest
 
 import lmdb
-import shlex
 import lmdb.tool
-
 import testlib
 
 def call_tool(cmdline):
-    return lmdb.tool.main(shlex.split(cmdline))
+    if sys.platform == 'win32':
+        args = cmdline.split()
+    else:
+        args = shlex.split(cmdline)
+    return lmdb.tool.main(args)
 
 class ToolTest(testlib.LmdbTest):
     def test_cmd_get(self):


### PR DESCRIPTION
Resolves #219.

Fix missing bytes encoding in parameter to rewrite command and the default --env option

Add regression tests for both.