### PR TITLE
Resolve Dupsort putmulti append=True bug

### DIFF
--- a/lib/py-lmdb/preload.h
+++ b/lib/py-lmdb/preload.h
@@ -23,6 +23,8 @@
 #ifndef LMDB_PRELOAD_H
 #define LMDB_PRELOAD_H
 
+#include <stdlib.h>
+
 /**
  * Touch a byte from every page in `x`, causing any read faults necessary for
  * copying the value to occur. This should be called with the GIL released, in
@@ -37,7 +39,7 @@
 static void preload(int rc, void *x, size_t size) {
     if(rc == 0) {
         volatile char j;
-        int i;
+        size_t i;
         for(i = 0; i < size; i += 4096) {
             j = ((volatile char *)x)[i];
         }

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -99,7 +99,7 @@ O_0111 = int('0111', 8)
 EMPTY_BYTES = UnicodeType().encode()
 
 
-# Used to track context across CFFI callbcks.
+# Used to track context across CFFI callbacks.
 _callbacks = threading.local()
 
 _CFFI_CDEF = '''
@@ -237,6 +237,7 @@ _CFFI_CDEF = '''
     #define MDB_VERSION_MISMATCH ...
 
     #define MDB_APPEND ...
+    #define MDB_APPENDDUP ...
     #define MDB_CP_COMPACT ...
     #define MDB_CREATE ...
     #define MDB_DUPFIXED ...
@@ -2150,7 +2151,10 @@ class Cursor(object):
         if not overwrite:
             flags |= _lib.MDB_NOOVERWRITE
         if append:
-            flags |= _lib.MDB_APPEND
+            if self.txn._db._flags & _lib.MDB_DUPSORT:
+                flags |= _lib.MDB_APPENDDUP
+            else:
+                flags |= _lib.MDB_APPEND
 
         added = 0
         skipped = 0

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -2244,7 +2244,7 @@ cursor_put_multi(CursorObject *self, PyObject *args, PyObject *kwds)
         flags |= MDB_NOOVERWRITE;
     }
     if(arg.append) {
-        flags |= MDB_APPEND;
+        flags |= (self->trans->db->flags & MDB_DUPSORT) ? MDB_APPENDDUP : MDB_APPEND;
     }
 
     if(! ((iter = PyObject_GetIter(arg.items)))) {

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -50,7 +50,7 @@ class ContextManagerTest(unittest.TestCase):
         try:
             with txn.cursor() as curs:
                 curs.put(123, 123)
-        except:
+        except Exception:
             pass
         self.assertRaises(Exception, lambda: curs.get(B('foo')))
 
@@ -174,6 +174,21 @@ class PutmultiTest(CursorTestBase):
         self.assertRaises(Exception,
              lambda: self.c.putmulti(range(2)))
 
+    def test_dupsort(self):
+        _, env = testlib.temp_env()
+        db1 = env.open_db(B('db1'), dupsort=True)
+        txn = env.begin(write=True, db=db1)
+        with txn.cursor() as c:
+            tups = [BT('a', 'value1'), BT('b', 'value1'), BT('b', 'value2')]
+            assert (3, 3) == c.putmulti(tups)
+
+    def test_dupsort_append(self):
+        _, env = testlib.temp_env()
+        db1 = env.open_db(B('db1'), dupsort=True)
+        txn = env.begin(write=True, db=db1)
+        with txn.cursor() as c:
+            tups = [BT('a', 'value1'), BT('b', 'value1'), BT('b', 'value2')]
+            assert (3, 3) == c.putmulti(tups, append=True)
 
 class ReplaceTest(CursorTestBase):
     def test_replace(self):

--- a/tests/txn_test.py
+++ b/tests/txn_test.py
@@ -28,11 +28,8 @@ import weakref
 
 import testlib
 from testlib import B
-from testlib import BT
-from testlib import OCT
 from testlib import INT_TYPES
 from testlib import BytesType
-from testlib import UnicodeType
 
 import lmdb
 


### PR DESCRIPTION
Previously, cursor.putmulti failed to use the right LMDB parameter to put when append=True. Now it will automatically use MDB_APPENDDUP when the database is dupsort.

Resolves #235.