### PR TITLE
Allow _Database.flags to take no arguments

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -1185,9 +1185,12 @@ class _Database(object):
             raise _error("mdb_dbi_flags", rc)
         self._flags = flags_[0]
 
-    def flags(self, txn):
+    def flags(self, *args):
         """Return the database's associated flags as a dict of _Database
         constructor kwargs."""
+        if len(args) > 1:
+            raise TypeError('flags takes 0 or 1 arguments')
+
         return {
             'reverse_key': bool(self._flags & _lib.MDB_REVERSEKEY),
             'dupsort': bool(self._flags & _lib.MDB_DUPSORT),

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -1041,23 +1041,11 @@ db_flags(DbObject *self, PyObject *args, PyObject *kwds)
     PyObject *dct;
     unsigned int f;
 
-    struct db_flags {
-        TransObject *txn;
-    } arg = {NULL};
-
-    static const struct argspec argspec[] = {
-        {"txn", ARG_TRANS, OFFSET(db_flags, txn)}
-    };
-
-    static PyObject *cache = NULL;
-    if(parse_args(self->valid, SPECSIZE(), argspec, &cache, args, kwds, &arg)) {
-        return NULL;
-    }
-    if(! arg.txn) {
-        return type_error("'txn' argument required");
-    }
-    if(! arg.txn->valid) {
-        return err_invalid();
+    if (args) {
+        Py_ssize_t size = PyTuple_GET_SIZE(args);
+        if(size > 1) {
+            return type_error("too many positional arguments.");
+        }
     }
 
     dct = PyDict_New();

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -704,6 +704,9 @@ class OpenDbTest(unittest.TestCase):
             key = B('%s-%s' % (flag, val))
             db = env.open_db(key, txn=txn, **{flag: val})
             assert db.flags(txn)[flag] == val
+            assert db.flags(None)[flag] == val
+            assert db.flags()[flag] == val
+            self.assertRaises(TypeError, lambda: db.flags(1, 2, 3))
 
         txn.commit()
         # Test flag persistence.


### PR DESCRIPTION
The txn argument was unused but validated.  It is now not validated. The flags method now takes 0 or 1 arguments.

Resolves #239.