### PR TITLE
Partial object rejigger

### DIFF
--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -861,33 +861,35 @@ make_trans(EnvObject *env, DbObject *db, TransObject *parent, int write, int buf
         self = env->spare_txns;
         DEBUG("found freelist txn; self=%p self->txn=%p", self, self->txn)
         env->spare_txns = self->spare_next;
-        env->max_spare_txns++;
-        self->flags &= ~TRANS_SPARE;
-        _Py_NewReference((PyObject *)self);
-        UNLOCKED(rc, mdb_txn_renew(self->txn));
 
+        UNLOCKED(rc, mdb_txn_renew(self->txn));
         if(rc) {
             mdb_txn_abort(self->txn);
-            self->txn = NULL;
+            PyObject_Del(self);
+            return err_set("mdb_txn_begin", rc);
         }
+
+        env->max_spare_txns++;
+        self->flags &= ~TRANS_SPARE;
+
     } else {
+        MDB_txn *txn;
         if(write && env->readonly) {
             const char *msg = "Cannot start write transaction with read-only env";
             return err_set(msg, EACCES);
         }
 
-        if(! ((self = PyObject_New(TransObject, &PyTransaction_Type)))) {
-            return NULL;
+        flags = write ? 0 : MDB_RDONLY;
+        UNLOCKED(rc, mdb_txn_begin(env->env, parent_txn, flags, &txn));
+        if(rc) {
+            return err_set("mdb_txn_begin", rc);
         }
 
-        flags = write ? 0 : MDB_RDONLY;
-        UNLOCKED(rc, mdb_txn_begin(env->env, parent_txn, flags, &self->txn));
-    }
-
-    if(rc) {
-        _Py_ForgetReference((PyObject *)self);
-        PyObject_Del(self);
-        return err_set("mdb_txn_begin", rc);
+        if(! ((self = PyObject_New(TransObject, &PyTransaction_Type)))) {
+            mdb_txn_abort(txn);
+            return NULL;
+        }
+        self->txn = txn;
     }
 
     OBJECT_INIT(self)
@@ -917,6 +919,7 @@ static PyObject *
 make_cursor(DbObject *db, TransObject *trans)
 {
     CursorObject *self;
+    MDB_cursor *curs;
     int rc;
 
     if(! trans->valid) {
@@ -928,17 +931,21 @@ make_cursor(DbObject *db, TransObject *trans)
         return NULL;
     }
 
-    self = PyObject_New(CursorObject, &PyCursor_Type);
-    UNLOCKED(rc, mdb_cursor_open(trans->txn, db->dbi, &self->curs));
+    UNLOCKED(rc, mdb_cursor_open(trans->txn, db->dbi, &curs));
     if(rc) {
-        _Py_ForgetReference((PyObject *)self);
-        PyObject_Del(self);
         return err_set("mdb_cursor_open", rc);
+    }
+
+    self = PyObject_New(CursorObject, &PyCursor_Type);
+    if (!self) {
+        mdb_cursor_close(curs);
+        return NULL;
     }
 
     DEBUG("sizeof cursor = %d", (int) sizeof *self)
     OBJECT_INIT(self)
     LINK_CHILD(trans, self)
+    self->curs = curs;
     self->positioned = 0;
     self->key.mv_size = 0;
     self->val.mv_size = 0;
@@ -2569,14 +2576,17 @@ static PyObject *
 new_iterator(CursorObject *cursor, IterValFunc val_func, MDB_cursor_op op)
 {
     IterObject *iter = PyObject_New(IterObject, &PyIterator_Type);
-    if(iter) {
-        iter->val_func = val_func;
-        iter->curs = cursor;
-        Py_INCREF(cursor);
-        iter->started = 0;
-        iter->op = op;
+    if (!iter) {
+        return NULL;
     }
-    DEBUG("new_iterator: %#p", (void *)iter)
+
+    iter->val_func = val_func;
+    iter->curs = cursor;
+    Py_INCREF(cursor);
+    iter->started = 0;
+    iter->op = op;
+
+    DEBUG("new_iterator: %p", (void *)iter)
     return (PyObject *) iter;
 }
 
@@ -2980,15 +2990,17 @@ trans_dealloc(TransObject *self)
         self->spare_next = self->env->spare_txns;
         self->env->spare_txns = self;
         self->env->max_spare_txns--;
+        Py_INCREF(self);
 
         Py_CLEAR(self->db);
         UNLINK_CHILD(self->env, self)
         Py_CLEAR(self->env);
-    } else {
-        MDEBUG("deleting trans")
-        trans_clear(self);
-        PyObject_Del(self);
+        return;
     }
+
+    MDEBUG("deleting trans")
+    trans_clear(self);
+    PyObject_Del(self);
 }
 
 /**

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -948,7 +948,9 @@ make_cursor(DbObject *db, TransObject *trans)
     self->curs = curs;
     self->positioned = 0;
     self->key.mv_size = 0;
+    self->key.mv_data = NULL;
     self->val.mv_size = 0;
+    self->val.mv_data = NULL;
     self->trans = trans;
     self->last_mutation = trans->mutations;
     self->dbi_flags = db->flags;

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -272,7 +272,7 @@ class PreloadTest(CursorTestBase):
         self.c.value()
         minflts_after_value = resource.getrusage(resource.RUSAGE_THREAD)[6]
 
-        epsilon = 5
+        epsilon = 20
 
         # Setting the position doesn't prefault the data
         assert minflts_after_key - minflts_before < epsilon

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -31,7 +31,6 @@ import testlib
 from testlib import B
 from testlib import BT
 
-
 class ContextManagerTest(unittest.TestCase):
     def tearDown(self):
         testlib.cleanup()

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -23,14 +23,12 @@
 from __future__ import absolute_import
 from __future__ import with_statement
 import os
-import signal
 import sys
 import unittest
 import weakref
 
 import testlib
 from testlib import B
-from testlib import BT
 from testlib import OCT
 from testlib import INT_TYPES
 from testlib import UnicodeType

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -38,7 +38,6 @@ except ImportError:
 
 import lmdb
 
-
 _cleanups = []
 
 def cleanup():
@@ -104,11 +103,8 @@ def debug_collect():
             # PyPy doesn't collect objects with __del__ on first attempt.
             gc.collect()
 
-
-# Handle moronic Python >=3.0 <3.3.
 UnicodeType = getattr(__builtin__, 'unicode', str)
 BytesType = getattr(__builtin__, 'bytes', str)
-
 
 try:
     INT_TYPES = (int, long)


### PR DESCRIPTION
Change initialization order to avoid partially constructed objects.

Fix minor uninitialized memory issue when accessing the key or the value of an unpositioned cursor.

Resolves #245 
