### PR TITLE
Allow environment copy to be executed against a passed-in transaction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ python:
   - 3.8
   - 3.9-dev
   - pypy
-  - pypy3
+  # - pypy3
   # - nightly
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
+---
 language: python
 
 matrix:
   exclude:
-  - python: pypy
-    env: LMDB_FORCE_CPYTHON=1
+    - python: pypy
+      env: LMDB_FORCE_CPYTHON=1
+    - python: pypy
+      env: LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
+    - python: pypy3
+      env: LMDB_FORCE_CPYTHON=1
+    - python: pypy3
+      env: LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
 
 python:
   - 2.7
@@ -12,13 +19,16 @@ python:
   - 3.6
   - 3.7
   - 3.8
-  - 3.9
-  # - nightly
+  - 3.9-dev
   - pypy
+  - pypy3
+  # - nightly
 
 env:
   - LMDB_FORCE_CFFI=1
   - LMDB_FORCE_CPYTHON=1
+  - LMDB_FORCE_CFFI=1 LMDB_PURE=1
+  - LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
 install:
   - sudo apt-get install gdb
   - pip install cffi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,8 @@ artifacts:
 install:
   # http://springflex.blogspot.co.uk/2014/02/how-to-fix-valueerror-when-trying-to.html. Works for 33-x64 only.
   - 'COPY "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsamd64.bat"'
-  - '%PYTHON%\scripts\pip.exe install wheel pytest patch .'
+  - '%PYTHON%\scripts\pip.exe install wheel patch'
+  - '%PYTHON%\scripts\pip.exe install pytest .'
 
 build_script:
   - '%PYTHON%\python.exe setup.py bdist_egg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ artifacts:
 install:
   # http://springflex.blogspot.co.uk/2014/02/how-to-fix-valueerror-when-trying-to.html. Works for 33-x64 only.
   - 'COPY "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsamd64.bat"'
-  - '%PYTHON%\scripts\pip.exe install wheel pytest  .'
+  - '%PYTHON%\scripts\pip.exe install wheel pytest patch .'
 
 build_script:
   - '%PYTHON%\python.exe setup.py bdist_egg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ artifacts:
 install:
   # http://springflex.blogspot.co.uk/2014/02/how-to-fix-valueerror-when-trying-to.html. Works for 33-x64 only.
   - 'COPY "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvars64.bat" "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\bin\vcvarsamd64.bat"'
-  - '%PYTHON%\scripts\pip.exe install wheel patch'
+  - '%PYTHON%\scripts\pip.exe install wheel patch-ng'
   - '%PYTHON%\scripts\pip.exe install pytest .'
 
 build_script:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,11 @@ built statically by default. If your system distribution includes LMDB, set the
 ``LMDB_FORCE_SYSTEM`` environment variable, and optionally ``LMDB_INCLUDEDIR``
 and ``LMDB_LIBDIR`` prior to invoking ``setup.py``.
 
+By default, the LMDB library is patched before building.  This patch (located
+at ``lib/py-lmdb/env-copy-txn.patch``) provides a minor feature:  the ability
+to copy/backup an environment under a particular transaction.   If you prefer
+to bypass the patch, set the environment variable ``LMDB_PURE``.
+
 The CFFI variant depends on CFFI, which in turn depends on ``libffi``, which
 may need to be installed from a package. On CPython, both variants additionally
 depend on the CPython development headers. On Debian/Ubuntu:

--- a/lib/py-lmdb/env-copy-txn.patch
+++ b/lib/py-lmdb/env-copy-txn.patch
@@ -1,0 +1,152 @@
+diff --git a/libraries/liblmdb/lmdb.h b/libraries/liblmdb/lmdb.h
+index 2f55290..8f6a21e 100644
+--- a/libraries/liblmdb/lmdb.h
++++ b/libraries/liblmdb/lmdb.h
+@@ -682,9 +682,12 @@ int  mdb_env_copyfd(MDB_env *env, mdb_filehandle_t fd);
+ 	 *		consumes more CPU and runs more slowly than the default.
+ 	 *		Currently it fails if the environment has suffered a page leak.
+ 	 * </ul>
++	 * @param[in] txn Transaction used for the copy.  If NULL, a temporary
++	 * transaction will be used.
+ 	 * @return A non-zero error value on failure and 0 on success.
+ 	 */
+ int  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags);
++int  mdb_env_copy3(MDB_env *env, const char *path, unsigned int flags, MDB_txn *txn);
+ 
+ 	/** @brief Copy an LMDB environment to the specified file descriptor,
+ 	 *	with options.
+@@ -701,9 +704,12 @@ int  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags);
+ 	 * have already been opened for Write access.
+ 	 * @param[in] flags Special options for this operation.
+ 	 * See #mdb_env_copy2() for options.
++	 * @param[in] txn Transaction used for the copy.  If NULL, a temporary
++	 * transaction will be used.
+ 	 * @return A non-zero error value on failure and 0 on success.
+ 	 */
+ int  mdb_env_copyfd2(MDB_env *env, mdb_filehandle_t fd, unsigned int flags);
++int  mdb_env_copyfd3(MDB_env *env, mdb_filehandle_t fd, unsigned int flags, MDB_txn *txn);
+ 
+ 	/** @brief Return statistics about the LMDB environment.
+ 	 *
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+index 692feaa..4de0d0a 100644
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -9309,12 +9309,12 @@ done:
+ 
+ 	/** Copy environment with compaction. */
+ static int ESECT
+-mdb_env_copyfd1(MDB_env *env, HANDLE fd)
++mdb_env_copyfd1(MDB_env *env, HANDLE fd, MDB_txn *txn)
+ {
+ 	MDB_meta *mm;
+ 	MDB_page *mp;
+ 	mdb_copy my = {0};
+-	MDB_txn *txn = NULL;
++	MDB_txn *orig_txn = txn;
+ 	pthread_t thr;
+ 	pgno_t root, new_root;
+ 	int rc = MDB_SUCCESS;
+@@ -9360,9 +9360,11 @@ mdb_env_copyfd1(MDB_env *env, HANDLE fd)
+ 	if (rc)
+ 		goto done;
+ 
+-	rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+-	if (rc)
+-		goto finish;
++	if (!txn) {
++		rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
++		if (rc)
++			goto finish;
++	}
+ 
+ 	mp = (MDB_page *)my.mc_wbuf[0];
+ 	memset(mp, 0, NUM_METAS * env->me_psize);
+@@ -9422,7 +9424,8 @@ finish:
+ 		my.mc_error = rc;
+ 	mdb_env_cthr_toggle(&my, 1 | MDB_EOF);
+ 	rc = THREAD_FINISH(thr);
+-	mdb_txn_abort(txn);
++	if (!orig_txn)
++		mdb_txn_abort(txn);
+ 
+ done:
+ #ifdef _WIN32
+@@ -9440,9 +9443,9 @@ done2:
+ 
+ 	/** Copy environment as-is. */
+ static int ESECT
+-mdb_env_copyfd0(MDB_env *env, HANDLE fd)
++mdb_env_copyfd0(MDB_env *env, HANDLE fd, MDB_txn *txn)
+ {
+-	MDB_txn *txn = NULL;
++	MDB_txn *orig_txn = txn;
+ 	mdb_mutexref_t wmutex = NULL;
+ 	int rc;
+ 	size_t wsize, w3;
+@@ -9459,9 +9462,11 @@ mdb_env_copyfd0(MDB_env *env, HANDLE fd)
+ 	/* Do the lock/unlock of the reader mutex before starting the
+ 	 * write txn.  Otherwise other read txns could block writers.
+ 	 */
+-	rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+-	if (rc)
+-		return rc;
++	if (!txn) {
++		rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
++		if (rc)
++			return rc;
++	}
+ 
+ 	if (env->me_txns) {
+ 		/* We must start the actual read txn after blocking writers */
+@@ -9534,17 +9539,24 @@ mdb_env_copyfd0(MDB_env *env, HANDLE fd)
+ 	}
+ 
+ leave:
+-	mdb_txn_abort(txn);
++	if (!orig_txn)
++		mdb_txn_abort(txn);
+ 	return rc;
+ }
+ 
+ int ESECT
+-mdb_env_copyfd2(MDB_env *env, HANDLE fd, unsigned int flags)
++mdb_env_copyfd3(MDB_env *env, HANDLE fd, unsigned int flags, MDB_txn *txn)
+ {
+ 	if (flags & MDB_CP_COMPACT)
+-		return mdb_env_copyfd1(env, fd);
++		return mdb_env_copyfd1(env, fd, txn);
+ 	else
+-		return mdb_env_copyfd0(env, fd);
++		return mdb_env_copyfd0(env, fd, txn);
++}
++
++int ESECT
++mdb_env_copyfd2(MDB_env *env, HANDLE fd, unsigned int flags)
++{
++	return mdb_env_copyfd3(env, fd, flags, NULL);
+ }
+ 
+ int ESECT
+@@ -9555,6 +9567,12 @@ mdb_env_copyfd(MDB_env *env, HANDLE fd)
+ 
+ int ESECT
+ mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags)
++{
++	return mdb_env_copy3(env, path, flags, NULL);
++}
++
++int ESECT
++mdb_env_copy3(MDB_env *env, const char *path, unsigned int flags, MDB_txn *txn)
+ {
+ 	int rc;
+ 	MDB_name fname;
+@@ -9566,7 +9584,7 @@ mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags)
+ 		mdb_fname_destroy(fname);
+ 	}
+ 	if (rc == MDB_SUCCESS) {
+-		rc = mdb_env_copyfd2(env, newfd, flags);
++		rc = mdb_env_copyfd3(env, newfd, flags, txn);
+ 		if (close(newfd) < 0 && rc == MDB_SUCCESS)
+ 			rc = ErrCode();
+ 	}

--- a/lib/py-lmdb/env-copy-txn.patch
+++ b/lib/py-lmdb/env-copy-txn.patch
@@ -1,13 +1,15 @@
 diff --git a/libraries/liblmdb/lmdb.h b/libraries/liblmdb/lmdb.h
-index 2f55290..8f6a21e 100644
+index 2f55290..6691b94 100644
 --- a/libraries/liblmdb/lmdb.h
 +++ b/libraries/liblmdb/lmdb.h
-@@ -682,9 +682,12 @@ int  mdb_env_copyfd(MDB_env *env, mdb_filehandle_t fd);
+@@ -682,9 +682,14 @@ int  mdb_env_copyfd(MDB_env *env, mdb_filehandle_t fd);
  	 *		consumes more CPU and runs more slowly than the default.
  	 *		Currently it fails if the environment has suffered a page leak.
  	 * </ul>
 +	 * @param[in] txn Transaction used for the copy.  If NULL, a temporary
-+	 * transaction will be used.
++	 * transaction will be used.  This is only valid if the #MDB_CP_COMPACT
++	 * flag is set.
++	 *
  	 * @return A non-zero error value on failure and 0 on success.
  	 */
  int  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags);
@@ -15,12 +17,13 @@ index 2f55290..8f6a21e 100644
  
  	/** @brief Copy an LMDB environment to the specified file descriptor,
  	 *	with options.
-@@ -701,9 +704,12 @@ int  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags);
+@@ -701,9 +706,13 @@ int  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags);
  	 * have already been opened for Write access.
  	 * @param[in] flags Special options for this operation.
  	 * See #mdb_env_copy2() for options.
 +	 * @param[in] txn Transaction used for the copy.  If NULL, a temporary
-+	 * transaction will be used.
++	 * transaction will be used.  This is only valid if the #MDB_CP_COMPACT
++	 * flag is set.
  	 * @return A non-zero error value on failure and 0 on success.
  	 */
  int  mdb_env_copyfd2(MDB_env *env, mdb_filehandle_t fd, unsigned int flags);
@@ -29,7 +32,7 @@ index 2f55290..8f6a21e 100644
  	/** @brief Return statistics about the LMDB environment.
  	 *
 diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
-index 692feaa..4de0d0a 100644
+index 692feaa..5fdabd9 100644
 --- a/libraries/liblmdb/mdb.c
 +++ b/libraries/liblmdb/mdb.c
 @@ -9309,12 +9309,12 @@ done:
@@ -72,41 +75,7 @@ index 692feaa..4de0d0a 100644
  
  done:
  #ifdef _WIN32
-@@ -9440,9 +9443,9 @@ done2:
- 
- 	/** Copy environment as-is. */
- static int ESECT
--mdb_env_copyfd0(MDB_env *env, HANDLE fd)
-+mdb_env_copyfd0(MDB_env *env, HANDLE fd, MDB_txn *txn)
- {
--	MDB_txn *txn = NULL;
-+	MDB_txn *orig_txn = txn;
- 	mdb_mutexref_t wmutex = NULL;
- 	int rc;
- 	size_t wsize, w3;
-@@ -9459,9 +9462,11 @@ mdb_env_copyfd0(MDB_env *env, HANDLE fd)
- 	/* Do the lock/unlock of the reader mutex before starting the
- 	 * write txn.  Otherwise other read txns could block writers.
- 	 */
--	rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
--	if (rc)
--		return rc;
-+	if (!txn) {
-+		rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
-+		if (rc)
-+			return rc;
-+	}
- 
- 	if (env->me_txns) {
- 		/* We must start the actual read txn after blocking writers */
-@@ -9534,17 +9539,24 @@ mdb_env_copyfd0(MDB_env *env, HANDLE fd)
- 	}
- 
- leave:
--	mdb_txn_abort(txn);
-+	if (!orig_txn)
-+		mdb_txn_abort(txn);
- 	return rc;
+@@ -9539,12 +9542,22 @@ leave:
  }
  
  int ESECT
@@ -117,8 +86,11 @@ index 692feaa..4de0d0a 100644
 -		return mdb_env_copyfd1(env, fd);
 +		return mdb_env_copyfd1(env, fd, txn);
  	else
--		return mdb_env_copyfd0(env, fd);
-+		return mdb_env_copyfd0(env, fd, txn);
++	{
++		if (txn) /* may only use txn with compact */
++			return EINVAL;
+ 		return mdb_env_copyfd0(env, fd);
++	}
 +}
 +
 +int ESECT
@@ -128,7 +100,7 @@ index 692feaa..4de0d0a 100644
  }
  
  int ESECT
-@@ -9555,6 +9567,12 @@ mdb_env_copyfd(MDB_env *env, HANDLE fd)
+@@ -9555,6 +9568,12 @@ mdb_env_copyfd(MDB_env *env, HANDLE fd)
  
  int ESECT
  mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags)
@@ -141,7 +113,7 @@ index 692feaa..4de0d0a 100644
  {
  	int rc;
  	MDB_name fname;
-@@ -9566,7 +9584,7 @@ mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags)
+@@ -9566,7 +9585,7 @@ mdb_env_copy2(MDB_env *env, const char *path, unsigned int flags)
  		mdb_fname_destroy(fname);
  	}
  	if (rc == MDB_SUCCESS) {

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ else:
 if patch_lmdb_source:
     if sys.platform.startswith('win'):
         try:
-            import patch
+            import patch_ng as patch
         except ImportError:
             raise Exception('Building py-lmdb from source on Windows requires the "patch" python module.')
 
@@ -108,8 +108,11 @@ if patch_lmdb_source:
 
     # Copy away the lmdb source then patch it
     if sys.platform.startswith('win'):
-        patchset = patch.fromfile('lib' + os.sep + 'py-lmdb' + os.sep + 'env-copy-txn.patch')
-        patchset.apply(3, root=dest)
+        patchfile = 'lib' + os.sep + 'py-lmdb' + os.sep + 'env-copy-txn.patch'
+        patchset = patch.fromfile(patchfile)
+        rv = patchset.apply(2, root=dest)
+        if not rv:
+            raise Exception('Applying patch failed')
     else:
         rv = os.system('/usr/bin/patch -N -p3 -d build/lib < lib/py-lmdb/env-copy-txn.patch')
         if rv:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ from __future__ import with_statement
 
 import os
 import sys
+import shutil
 import platform
 
 from setuptools import Extension
@@ -64,17 +65,53 @@ else:
 
 extra_include_dirs += ['lib/py-lmdb']
 
+patch_lmdb_source = False
+
 if os.getenv('LMDB_FORCE_SYSTEM') is not None:
     print('py-lmdb: Using system version of liblmdb.')
     extra_sources = []
     extra_include_dirs += []
     libraries = ['lmdb']
-else:
-    print('py-lmdb: Using bundled liblmdb; override with LMDB_FORCE_SYSTEM=1.')
+elif os.getenv('LMDB_PURE') is not None:
+    print('py-lmdb: Using bundled unmodified liblmdb; override with LMDB_FORCE_SYSTEM=1.')
     extra_sources = ['lib/mdb.c', 'lib/midl.c']
     extra_include_dirs += ['lib']
     libraries = []
+else:
+    print('py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.')
+    extra_sources = ['build/lib/mdb.c', 'build/lib/midl.c']
+    extra_include_dirs += ['build/lib']
+    libraries = []
+    patch_lmdb_source = True
 
+if patch_lmdb_source:
+    if sys.platform.startswith('win'):
+        try:
+            import patch
+        except ImportError:
+            raise Exception('Building py-lmdb from source on Windows requires the "patch" python module.')
+
+    # Clean out any previously patched files
+    dest = 'build' + os.sep + 'lib'
+    try:
+        os.mkdir('build')
+    except Exception:
+        pass
+
+    try:
+        shutil.rmtree(dest)
+    except Exception:
+        pass
+    shutil.copytree('lib', dest)
+
+    # Copy away the lmdb source then patch it
+    if sys.platform.startswith('win'):
+        patchset = patch.fromfile('lib' + os.sep + 'py-lmdb' + os.sep + 'env-copy-txn.patch')
+        patchset.apply(3, root=dest)
+    else:
+        rv = os.system('/usr/bin/patch -N -p3 -d build/lib < lib/py-lmdb/env-copy-txn.patch')
+        if rv:
+            raise Exception('Applying patch failed')
 
 # distutils perplexingly forces NDEBUG for package code!
 extra_compile_args = ['-UNDEBUG']
@@ -91,7 +128,7 @@ if not os.getenv('LMDB_MAINTAINER'):
 # inttypes.h and stdint.h lack, and to avoid having to modify the LMDB source
 # code. Advapi32 is needed for LMDB's use of Windows security APIs.
 p = sys.version.find('MSC v.')
-msvc_ver = int(sys.version[p+6:p+10]) if p != -1 else None
+msvc_ver = int(sys.version[p + 6: p + 10]) if p != -1 else None
 
 if sys.platform.startswith('win'):
     # If running on Visual Studio<=2010 we must provide <stdint.h>. Newer
@@ -149,36 +186,34 @@ def grep_version():
                 return eval(line.split()[-1])
 
 setup(
-    name = 'lmdb',
-    version = grep_version(),
-    description = "Universal Python binding for the LMDB 'Lightning' Database",
-    long_description = "Universal Python binding for the LMDB 'Lightning' Database",
-    long_description_content_type = "text/plain",
-    author = 'David Wilson',
-    maintainer = 'Nic Watson',
-    license = 'OpenLDAP BSD',
-    url = 'http://github.com/jnwatson/py-lmdb/',
-    packages = ['lmdb'],
-    classifiers = [
+    name='lmdb',
+    version=grep_version(),
+    description="Universal Python binding for the LMDB 'Lightning' Database",
+    long_description="Universal Python binding for the LMDB 'Lightning' Database",
+    long_description_content_type="text/plain",
+    author='David Wilson',
+    maintainer='Nic Watson',
+    license='OpenLDAP BSD',
+    url='http://github.com/jnwatson/py-lmdb/',
+    packages=['lmdb'],
+
+    classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.0",
-        "Programming Language :: Python :: 3.1",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",
     ],
-    ext_package = 'lmdb',
-    ext_modules = ext_modules,
-    install_requires = install_requires,
-    zip_safe = False
+    ext_package='lmdb',
+    ext_modules=ext_modules,
+    install_requires=install_requires,
 )

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ if patch_lmdb_source:
         try:
             import patch_ng as patch
         except ImportError:
-            raise Exception('Building py-lmdb from source on Windows requires the "patch" python module.')
+            raise Exception('Building py-lmdb from source on Windows requires the "patch-ng" python module.')
 
     # Clean out any previously patched files
     dest = 'build' + os.sep + 'lib'

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ else:
     extra_library_dirs = []
 
 extra_include_dirs += ['lib/py-lmdb']
+extra_compile_args = []
 
 patch_lmdb_source = False
 
@@ -81,6 +82,7 @@ else:
     print('py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.')
     extra_sources = ['build/lib/mdb.c', 'build/lib/midl.c']
     extra_include_dirs += ['build/lib']
+    extra_compile_args += ['-DHAVE_PATCHED_LMDB=1']
     libraries = []
     patch_lmdb_source = True
 
@@ -114,7 +116,7 @@ if patch_lmdb_source:
             raise Exception('Applying patch failed')
 
 # distutils perplexingly forces NDEBUG for package code!
-extra_compile_args = ['-UNDEBUG']
+extra_compile_args += ['-UNDEBUG']
 
 # Disable some Clang/GCC warnings.
 if not os.getenv('LMDB_MAINTAINER'):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013 The py-lmdb authors, all rights reserved.
+# Copyright 2013-2020 The py-lmdb authors, all rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted only as authorized by the OpenLDAP

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -35,6 +35,8 @@ from testlib import UnicodeType
 
 import lmdb
 
+# Whether we have the patch that allows env.copy* to take a txn
+have_txn_patch = lmdb.version(subpatch=True)[3]
 
 NO_READERS = UnicodeType('(no active readers)\n')
 
@@ -54,6 +56,11 @@ class VersionTest(unittest.TestCase):
         assert all(isinstance(i, INT_TYPES) for i in ver)
         assert all(i >= 0 for i in ver)
 
+    def test_version_subpatch(self):
+        ver = lmdb.version(subpatch=True)
+        assert len(ver) == 4
+        assert all(isinstance(i, INT_TYPES) for i in ver)
+        assert all(i >= 0 for i in ver)
 
 class OpenTest(unittest.TestCase):
     def tearDown(self):
@@ -417,7 +424,13 @@ class OtherMethodsTest(unittest.TestCase):
         txn.commit()
 
         dest_dir = testlib.temp_dir()
-        env.copy(dest_dir)
+
+        if have_txn_patch:
+            with env.begin() as txn:
+                self.assertRaises(Exception,
+                                  lambda: env.copy(dest_dir, txn=txn))
+
+        env.copy(dest_dir, compact=True)
         assert os.path.exists(dest_dir + '/data.mdb')
 
         cenv = lmdb.open(dest_dir)
@@ -442,11 +455,34 @@ class OtherMethodsTest(unittest.TestCase):
         ctxn = cenv.begin()
         assert ctxn.get(B('a')) == B('b')
 
+        # Test copy with transaction provided
+        dest_dir = testlib.temp_dir()
+        with env.begin(write=True) as txn:
+            copy_txn = env.begin()
+            txn.put(B('b'), B('b'))
+        assert ctxn.get(B('b')) is None
+
+        if have_txn_patch:
+
+            env.copy(dest_dir, compact=True, txn=copy_txn)
+            assert os.path.exists(dest_dir + '/data.mdb')
+
+            cenv = lmdb.open(dest_dir)
+            ctxn = cenv.begin()
+            assert ctxn.get(B('a')) == B('b')
+            # Verify that the write that occurred outside the txn isn't seen in the
+            # copy
+            assert ctxn.get(B('b')) is None
+
+        else:
+            self.assertRaises(Exception,
+                              lambda: env.copy(dest_dir, compact=True, txn=copy_txn))
+
         env.close()
         self.assertRaises(Exception,
             lambda: env.copy(testlib.temp_dir()))
 
-    def test_copyfd(self):
+    def test_copyfd_compact(self):
         path, env = testlib.temp_env()
         txn = env.begin(write=True)
         txn.put(B('a'), B('b'))
@@ -459,13 +495,38 @@ class OtherMethodsTest(unittest.TestCase):
         dstenv = lmdb.open(dst_path, subdir=False)
         dtxn = dstenv.begin()
         assert dtxn.get(B('a')) == B('b')
+        fp.close()
+
+        # Test copy with transaction provided
+        dst_path = testlib.temp_file(create=False)
+        fp = open(dst_path, 'wb')
+        with env.begin(write=True) as txn:
+            copy_txn = env.begin()
+            txn.put(B('b'), B('b'))
+        assert dtxn.get(B('b')) is None
+
+        if have_txn_patch:
+
+            env.copyfd(fp.fileno(), compact=True, txn=copy_txn)
+
+            dstenv = lmdb.open(dst_path, subdir=False)
+            dtxn = dstenv.begin()
+            assert dtxn.get(B('a')) == B('b')
+            # Verify that the write that occurred outside the txn isn't seen in the
+            # copy
+            assert dtxn.get(B('b')) is None
+            dstenv.close()
+
+        else:
+            self.assertRaises(Exception,
+                lambda: env.copyfd(fp.fileno(), compact=True, txn=copy_txn))
 
         env.close()
         self.assertRaises(Exception,
             lambda: env.copyfd(fp.fileno()))
         fp.close()
 
-    def test_copyfd_compact(self):
+    def test_copyfd(self):
         path, env = testlib.temp_env()
         txn = env.begin(write=True)
         txn.put(B('a'), B('b'))
@@ -473,7 +534,12 @@ class OtherMethodsTest(unittest.TestCase):
 
         dst_path = testlib.temp_file(create=False)
         fp = open(dst_path, 'wb')
-        env.copyfd(fp.fileno(), compact=True)
+
+        if have_txn_patch:
+            with env.begin() as txn:
+                self.assertRaises(Exception,
+                                  lambda: env.copyfd(fp.fileno(), txn=txn))
+        env.copyfd(fp.fileno())
 
         dstenv = lmdb.open(dst_path, subdir=False)
         dtxn = dstenv.begin()


### PR DESCRIPTION
This is implemented with a patch to the underlying LMDB library.