### PR TITLE
Optionally return structured array buffer for cursor.getmulti()

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -2077,13 +2077,14 @@ class Cursor(object):
                 optimization reducing the number of database lookups.
 
             `key_bytes`:
-                If database was opened with `dupsort=True` and `dupfixed=True`,
-                and database key size is also fixed, accepts the key size, in
-                bytes, resulting in this function returning a structured array
-                as a bytearray. The bytearray can be passed to NumPy as a
-                buffer to instantiate the structured array:
+                If `dupfixed_bytes` is set and database key size is fixed,
+                accepts the key size, in bytes, resulting in this function
+                returning a memoryview of the results as a structured array
+                of bytes. The structured array can be instantiated by passing
+                the memoryview buffer to NumPy:
 
-                ::
+                .. code-block:: python
+
                     key_bytes, val_bytes = 4, 8
                     dtype = np.dtype([(f'S{key_bytes}', f'S{val_bytes}}')])
                     arr = np.frombuffer(
@@ -2121,7 +2122,7 @@ class Cursor(object):
                             for i in range(0, len(val), dupfixed_bytes))
                         if key_bytes:
                             for k, v in gen:
-                                a += k + v
+                                a.extend(k + v)
                         else:
                             for k, v in gen:
                                 l.append((k, v))
@@ -2134,7 +2135,7 @@ class Cursor(object):
                         break
 
         if key_bytes:
-            return a
+            return memoryview(a)
         else:
             return l
 

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -2103,20 +2103,26 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
     struct cursor_get {
         PyObject *keys;
         int dupdata;
-        int dupfixed_bytes;
+        size_t dupfixed_bytes;
+        size_t key_bytes;
     } arg = {Py_None, 0, 0};
 
     int i, as_buffer;
     PyObject *iter, *item, *tup, *key, *val;
-    PyObject *ret = PyList_New(0);
+    PyObject *pylist = PyList_New(0);
     MDB_cursor_op get_op, next_op;
     bool done;
 
     static const struct argspec argspec[] = {
         {"keys", ARG_OBJ, OFFSET(cursor_get, keys)},
         {"dupdata", ARG_BOOL, OFFSET(cursor_get, dupdata)},
-        {"dupfixed_bytes", ARG_INT, OFFSET(cursor_get, dupfixed_bytes)}  // ARG_SIZE?
+        {"dupfixed_bytes", ARG_SIZE, OFFSET(cursor_get, dupfixed_bytes)},
+        {"key_bytes", ARG_SIZE, OFFSET(cursor_get, key_bytes)}
     };
+
+    size_t buffer_pos = 0, buffer_size = 8;
+    size_t key_bytes, val_bytes, item_size;
+    char *buffer;
 
     static PyObject *cache = NULL;
     if(parse_args(self->valid, SPECSIZE(), argspec, &cache, args, kwds, &arg)) {
@@ -2125,15 +2131,17 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
 
     if(arg.dupfixed_bytes < 0) {
         return type_error("dupfixed_bytes must be a positive integer.");
-    }else if (arg.dupfixed_bytes > 0 && !arg.dupdata) {
-        return type_error("dupdata is required for dupfixed_bytes.");
+    }else if ((arg.dupfixed_bytes > 0 || arg.key_bytes > 0) && !arg.dupdata) {
+        return type_error("dupdata is required for dupfixed_bytes/key_bytes.");
+    }else if (arg.key_bytes > 0 && !arg.dupfixed_bytes){
+        return type_error("dupfixed_bytes is required for key_bytes.");
     }
 
     if(! ((iter = PyObject_GetIter(arg.keys)))) {
         return NULL;
     }
 
-    /* Choose ops for dupfixed vs standard  */
+    /* Choose ops */
     if(arg.dupfixed_bytes) {
         get_op = MDB_GET_MULTIPLE;
         next_op = MDB_NEXT_MULTIPLE;
@@ -2143,11 +2151,15 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
     }
 
     as_buffer = self->trans->flags & TRANS_BUFFERS;
+    key_bytes = arg.key_bytes;
+    val_bytes = arg.dupfixed_bytes;
+    if (key_bytes) { /* Init structured array buffer */
+        item_size = key_bytes + val_bytes;
+        buffer = malloc(buffer_size * item_size);
+    }
 
     while((item = PyIter_Next(iter))) {
         MDB_val mkey;
-
-        // validate item?
 
         if(val_from_buffer(&mkey, item)) {
             Py_DECREF(item);
@@ -2156,7 +2168,7 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
         } /* val_from_buffer sets exception */
 
         self->key = mkey;
-        if(_cursor_get_c(self, MDB_SET_KEY)) { // MDB_SET?
+        if(_cursor_get_c(self, MDB_SET_KEY)) {
             Py_DECREF(item);
             Py_DECREF(iter);
             return NULL;
@@ -2164,12 +2176,10 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
 
         done = false;
         while (!done) {
-            //TODO valid cursor check?
 
             if(! self->positioned) {
                 done = true;
             }
-            // TODO check for mutation and refresh key?
             else if(_cursor_get_c(self, get_op)) {
                 Py_DECREF(item);
                 Py_DECREF(iter);
@@ -2186,7 +2196,7 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
                     if (tup && key && val) {
                         PyTuple_SET_ITEM(tup, 0, key);
                         PyTuple_SET_ITEM(tup, 1, val);
-                        PyList_Append(ret, tup);
+                        PyList_Append(pylist, tup);
                         Py_DECREF(tup);
                     } else {
                         Py_DECREF(key);
@@ -2195,26 +2205,42 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
                     }
                 } else {
                     /* dupfixed, MDB_GET_MULTIPLE returns batch, iterate values */
-                    int len = (int) self->val.mv_size/arg.dupfixed_bytes; // size_t?
-                    for(i=0; i<len; i++) {
+                    int items = (int) self->val.mv_size/arg.dupfixed_bytes; // size_t?
+
+                    for(i=0; i<items; i++) {
                         char *val_data = (char *) self->val.mv_data + (i * arg.dupfixed_bytes);
-                        if(as_buffer) {
-                            val = PyMemoryView_FromMemory(
-                                val_data, (size_t) arg.dupfixed_bytes, PyBUF_READ);
+                        if (key_bytes) {
+                            /* Add to array buffer */
+                            if (buffer_pos >= buffer_size) { // Grow buffer
+                                buffer_size = buffer_size * 2;
+                                buffer = realloc(buffer, buffer_size * item_size);
+                            }
+                            char *k = buffer + (buffer_pos * item_size);
+                            char *v = k + arg.key_bytes;
+                            memcpy(k, self->key.mv_data, arg.key_bytes);
+                            memcpy(v, val_data, arg.dupfixed_bytes);
+
+                            buffer_pos++;
                         } else {
-                            val = PyBytes_FromStringAndSize(
-                                val_data, (size_t) arg.dupfixed_bytes);
-                        }
-                        tup = PyTuple_New(2);
-                        if (tup && key && val) {
-                            Py_INCREF(key); // Hold key in loop
-                            PyTuple_SET_ITEM(tup, 0, key);
-                            PyTuple_SET_ITEM(tup, 1, val);
-                            PyList_Append(ret, tup);
-                            Py_DECREF(tup);
-                        } else {
-                            Py_DECREF(val);
-                            Py_DECREF(tup);
+                            /* Add to list of tuples */
+                            if(as_buffer) {
+                                val = PyMemoryView_FromMemory(
+                                    val_data, (size_t) arg.dupfixed_bytes, PyBUF_READ);
+                            } else {
+                                val = PyBytes_FromStringAndSize(
+                                    val_data, (size_t) arg.dupfixed_bytes);
+                            }
+                            tup = PyTuple_New(2);
+                            if (tup && key && val) {
+                                Py_INCREF(key); // Hold key in loop
+                                PyTuple_SET_ITEM(tup, 0, key);
+                                PyTuple_SET_ITEM(tup, 1, val);
+                                PyList_Append(pylist, tup);
+                                Py_DECREF(tup);
+                            } else {
+                                Py_DECREF(val);
+                                Py_DECREF(tup);
+                            }
                         }
                     }
                     Py_DECREF(key); // Release key
@@ -2240,7 +2266,13 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    return ret;
+    if (key_bytes){
+        size_t newsize = buffer_pos * item_size;
+        buffer = realloc(buffer, newsize);
+        return PyByteArray_FromStringAndSize(buffer, (Py_ssize_t)newsize);
+    } else {
+        return pylist;
+    }
 }
 
 /**

--- a/tests/getmulti_test.py
+++ b/tests/getmulti_test.py
@@ -65,10 +65,10 @@ class GetMultiTestDupsortDupfixedKeyfixed(GetMultiTestBase):
         super(GetMultiTestDupsortDupfixedKeyfixed, self).setUp(dupsort=dupsort, dupfixed=dupfixed)
 
     def testGetMulti(self):
-        key_bytes, val_bytes = 1, 1
+        val_bytes = 1
         arr = bytearray(self.c.getmulti(
             KEYSFIXED, dupdata=True,
-            dupfixed_bytes=val_bytes, key_bytes=key_bytes
+            dupfixed_bytes=val_bytes, keyfixed=True
         ))
         asserts = []
         for i, kv in enumerate(ITEMS_MULTI_FIXEDKEY):

--- a/tests/getmulti_test.py
+++ b/tests/getmulti_test.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import with_statement
 import unittest
 
-import testlib
+import testlib, struct
 from testlib import KEYSFIXED, ITEMS_MULTI_FIXEDKEY
 from testlib import putBigDataMultiFixed
 
@@ -66,17 +66,17 @@ class GetMultiTestDupsortDupfixedKeyfixed(GetMultiTestBase):
 
     def testGetMulti(self):
         key_bytes, val_bytes = 1, 1
-        arr = self.c.getmulti(
+        arr = bytearray(self.c.getmulti(
             KEYSFIXED, dupdata=True,
             dupfixed_bytes=val_bytes, key_bytes=key_bytes
-        )
+        ))
         asserts = []
         for i, kv in enumerate(ITEMS_MULTI_FIXEDKEY):
             key, val = kv
             asserts.extend((
-                int(arr[i*2]).to_bytes(length=key_bytes, byteorder='little') == key,
-                int(arr[i*2+1]).to_bytes(length=val_bytes, byteorder='little') == val)
-            )
+                struct.pack('b', arr[i*2]) == key,
+                struct.pack('b', arr[i*2+1]) == val
+            ))
         self.assertEqual(all(asserts), True)
 
 

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -137,28 +137,29 @@ KEYS2 = BL('a', 'b', 'baa', 'd', 'e', 'f', 'g', 'h')
 ITEMS2 = [(k, B('')) for k in KEYS2]
 REV_ITEMS2 = ITEMS2[::-1]
 VALUES2 = [B('') for k in KEYS2]
-VALUES2_MULTI = [(B('r'), B('s')) for k in KEYS2]
-ITEMS2_MULTI = [
-    (kv[0], v) for kv in list(zip(KEYS2, VALUES2_MULTI)) for v in kv[1]
+
+# ITEMS2_MULTI = [
+#     (kv[0], v) for kv in list(zip(KEYS2, VALUES2_MULTI)) for v in kv[1]
+#     ]
+KEYSFIXED = BL('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
+VALUES_MULTI = [(B('r'), B('s')) for k in KEYSFIXED]
+ITEMS_MULTI_FIXEDKEY = [
+    (kv[0], v) for kv in list(zip(KEYSFIXED, VALUES_MULTI)) for v in kv[1]
     ]
 
-def putData(t, db=None):
-    for k, v in ITEMS:
+def _put_items(items, t, db=None):
+    for k, v in items:
         if db:
             t.put(k, v, db=db)
         else:
             t.put(k, v)
+
+
+def putData(t, db=None):
+    _put_items(ITEMS, t, db=db)
 
 def putBigData(t, db=None):
-    for k, v in ITEMS2:
-        if db:
-            t.put(k, v, db=db)
-        else:
-            t.put(k, v)
+    _put_items(ITEMS2, t, db=db)
 
-def putBigDataMulti(t, db=None):
-    for k, v in ITEMS2_MULTI:
-        if db:
-            t.put(k, v, db=db) #defaults to dupdata=True
-        else:
-            t.put(k, v)
+def putBigDataMultiFixed(t, db=None):
+    _put_items(ITEMS_MULTI_FIXEDKEY, t, db=db)

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -138,9 +138,6 @@ ITEMS2 = [(k, B('')) for k in KEYS2]
 REV_ITEMS2 = ITEMS2[::-1]
 VALUES2 = [B('') for k in KEYS2]
 
-# ITEMS2_MULTI = [
-#     (kv[0], v) for kv in list(zip(KEYS2, VALUES2_MULTI)) for v in kv[1]
-#     ]
 KEYSFIXED = BL('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
 VALUES_MULTI = [(B('r'), B('s')) for k in KEYSFIXED]
 ITEMS_MULTI_FIXEDKEY = [


### PR DESCRIPTION
This adds an optimized codepath for marshaling getmulti() results into a NumPy array. In CPython it builds the structured array in a buffer and returns a memoryview to it. This is how to use it:

````
key_bytes, val_bytes = 4, 8
dtype = np.dtype([(f'S{key_bytes}', f'S{val_bytes}}')])
arr = np.frombuffer(
    cur.getmulti(keys, dupdata=True, dupfixed_bytes=val_bytes, key_bytes=key_bytes)
)
````

With this option, I think the argument names should probably change to something more consistent, like `key_bytes`/`val_bytes`, `key_size`/`val_size`, `dupfixed_key_bytes`/`dupfixed_val_bytes`, etc.