### PR TITLE
Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 language: python
-
+arch:
+  - amd64
+  - ppc64le
 matrix:
   exclude:
     - python: pypy
@@ -11,7 +13,31 @@ matrix:
       env: LMDB_FORCE_CPYTHON=1
     - python: pypy3
       env: LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
-
+ #poweron support exclude
+    - python: pypy
+      env: LMDB_FORCE_CPYTHON=1
+      arch: ppc64le
+    - python: pypy
+      env: LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
+      arch: ppc64le
+    - python: pypy3
+      env: LMDB_FORCE_CPYTHON=1
+      arch: ppc64le
+    - python: pypy3
+      env: LMDB_FORCE_CPYTHON=1 LMDB_PURE=1
+      arch: ppc64le
+    - python: pypy
+      env: LMDB_FORCE_CFFI=1
+      arch: ppc64le
+    - python: pypy
+      env: LMDB_FORCE_CFFI=1 LMDB_PURE=1
+      arch: ppc64le
+    - python: pypy3
+      env: LMDB_FORCE_CFFI=1
+      arch: ppc64le
+    - python: pypy3
+      env: LMDB_FORCE_CFFI=1 LMDB_PURE=1
+      arch: ppc64le
 python:
   - 2.7
   - 3.6


### PR DESCRIPTION
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, 
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.
