### PR TITLE
Use official OSI name in the license metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
     long_description_content_type="text/plain",
     author='David Wilson',
     maintainer='Nic Watson',
-    license='OpenLDAP BSD',
+    license='OLDAP-2.8',
     url='http://github.com/jnwatson/py-lmdb/',
     packages=['lmdb'],
 


### PR DESCRIPTION
This makes it easier for automatic license checkers to verify the license of this package.