### PR TITLE
Fix transactions freed by deallocation in child process

### DIFF
--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -1131,8 +1131,12 @@ env_clear(EnvObject *self)
 
     txn = self->spare_txn;
     if(txn) {
-        MDEBUG("killing spare txn %p", txn);
-        txn_abort(txn);
+        if (self->pid != getpid()) {
+            MDEBUG("In forked process, not killing spare txn %p", txn);
+        } else {
+            MDEBUG("killing spare txn %p", txn);
+            txn_abort(txn);
+        }
         self->spare_txn = NULL;
     }
 


### PR DESCRIPTION
Hi,

These patches prevent a child process removing a reader that was created in the parent process from the reader table on deallocation. This doesn't prevent any deliberate misuse of the transaction within a child process just unavoidable issues caused by deallocation e.g. when the child process exits.

Fixes #346 