### PR TITLE
fix/workaround CFFI path shenanigans

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -367,6 +367,9 @@ if not lmdb._reading_docs():
     if _have_patched_lmdb:
         _CFFI_CDEF += _CFFI_CDEF_PATCHED
 
+    _config_vars['extra_sources'] = [os.path.abspath('./build/lib/mdb.c'), os.path.abspath('./build/lib/midl.c')]
+    _config_vars['extra_include_dirs'] = [os.path.abspath('./lib/py-lmdb')]
+
     _ffi = cffi.FFI()
     _ffi.cdef(_CFFI_CDEF)
     _lib = _ffi.verify(_CFFI_VERIFY,


### PR DESCRIPTION
this is on PyPy: not sure what's going on, but CFFI seems to get confused and fails to find `mdb.c` - tried on with released package, from source, using PyPy releases and PyPy trunk.

```
cc1: fatal error: build/lib/mdb.c: No such file or directory
```

In the end, I just added `os.abspath` to hammer the paths, convert it to absolute paths when the paths are still correct to prevent them being not working anymore later in cffi.verify .. I'm not sure exactly where the location from which the relative paths are resolved changes, but with this fix, it now works, including pip installing from my working fork. please see my log deserts below. took me quite some time to nail it down. I love Python, but I hate that they (CPython) never had a properly defined official ABI. well. sh** & problems for years and many hours wasted for everyone;)

ah, I'll use my fork to point my dependent packages to, but of course, upstream fixing here, or even cffi, would be preferred of course!

first, error, then I edit and add 2 lines, then it works:

```
oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ which pypy
/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/bin/pypy
oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ pypy -V
Python 3.11.13 (96d4b7e66661, Jun 25 2025, 01:49:17)
[PyPy 7.3.20-alpha0 with GCC 10.2.1 20210130 (Red Hat 10.2.1-11)]
oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ which virtualenv
/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/bin/virtualenv
oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ virtualenv .venv
created virtual environment PyPy3.11.13.final.0-64 in 551ms
  creator PyPy3Posix(dest=/home/oberstet/scm/oberstet/py-lmdb/.venv, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, via=copy, app_data_dir=/home/oberstet/.local/share/virtualenv)
    added seed packages: pip==25.1.1, setuptools==80.9.0
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ source .venv/bin/activate
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ which virtualenv
/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/bin/virtualenv
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ which pypy
/home/oberstet/scm/oberstet/py-lmdb/.venv/bin/pypy
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ pypy -V
Python 3.11.13 (96d4b7e66661, Jun 25 2025, 01:49:17)
[PyPy 7.3.20-alpha0 with GCC 10.2.1 20210130 (Red Hat 10.2.1-11)]
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ which python
/home/oberstet/scm/oberstet/py-lmdb/.venv/bin/python
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ LMDB_FORCE_CFFI=1 python setup.py install
py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.
patching file lmdb.h
patching file mdb.c
Using cffi extension.
cc1: fatal error: build/lib/mdb.c: No such file or directory
compilation terminated.
Traceback (most recent call last):
  File "/home/oberstet/scm/oberstet/py-lmdb/lmdb/__init__.py", line 41, in <module>
    raise ImportError
ImportError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/spawn.py", line 87, in spawn
    subprocess.check_call(cmd, env=_inject_macos_ver(env))
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/usr/bin/gcc', '-pthread', '-DNDEBUG', '-O2', '-fPIC', '-Ilib/py-lmdb', '-Ibuild/lib', '-I/home/oberstet/scm/oberstet/py-lmdb/.venv/include', '-I/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/include/pypy3.11', '-c', 'build/lib/mdb.c', '-o', './build/lib/mdb.o', '-DHAVE_PATCHED_LMDB=1', '-UNDEBUG', '-w']' returned non-zero exit status 1.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/compilers/C/unix.py", line 221, in _compile
    self.spawn(compiler_so + cc_args + [src, '-o', obj] + extra_postargs)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/compilers/C/base.py", line 1158, in spawn
    spawn(cmd, dry_run=self.dry_run, **kwargs)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/spawn.py", line 93, in spawn
    raise DistutilsExecError(
distutils.errors.DistutilsExecError: command '/usr/bin/gcc' failed with exit code 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/ffiplatform.py", line 51, in _build
    dist.run_command('build_ext')
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/dist.py", line 1102, in run_command
    super().run_command(command)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/command/build_ext.py", line 96, in run
    _build_ext.run(self)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 368, in run
    self.build_extensions()
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 484, in build_extensions
    self._build_extensions_serial()
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 510, in _build_extensions_serial
    self.build_extension(ext)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/command/build_ext.py", line 261, in build_extension
    _build_ext.build_extension(self, ext)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/command/build_ext.py", line 565, in build_extension
    objects = 
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/compilers/C/base.py", line 655, in compile
    self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
  File "/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/compilers/C/unix.py", line 223, in _compile
    raise CompileError(msg)
distutils.compilers.C.errors.CompileError: command '/usr/bin/gcc' failed with exit code 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/oberstet/scm/oberstet/py-lmdb/setup.py", line 180, in <module>
    import lmdb.cffi
  File "/home/oberstet/scm/oberstet/py-lmdb/lmdb/__init__.py", line 48, in <module>
    from lmdb.cffi import *
  File "/home/oberstet/scm/oberstet/py-lmdb/lmdb/cffi.py", line 372, in <module>
    _lib = _ffi.verify(_CFFI_VERIFY,

           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/api.py", line 468, in verify
    lib = self.verifier.load_library()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/verifier.py", line 105, in load_library
    self._compile_module()
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/verifier.py", line 209, in _compile_module
    output_rel_filename = ffiplatform.compile(tmpdir, self.get_extension())
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/ffiplatform.py", line 20, in compile
    outputfilename = _build(tmpdir, ext, compiler_verbose, debug)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/lib/pypy3.11/cffi/ffiplatform.py", line 57, in _build
    raise VerificationError('%s: %s' % (e.__class__.__name__, e))
cffi.VerificationError: CompileError: command '/usr/bin/gcc' failed with exit code 1
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ git status
On branch fix-cffi-path-shenanigans
nothing to commit, working tree clean
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ git status
On branch fix-cffi-path-shenanigans
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   lmdb/cffi.py

no changes added to commit (use "git add" and/or "git commit -a")
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ git diff
diff --git a/lmdb/cffi.py b/lmdb/cffi.py
index 935e9b1..8fe8974 100644
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -367,6 +367,9 @@ if not lmdb._reading_docs():
     if _have_patched_lmdb:
         _CFFI_CDEF += _CFFI_CDEF_PATCHED
 
+    _config_vars['extra_sources'] = [os.path.abspath('./build/lib/mdb.c'), os.path.abspath('./build/lib/midl.c')]
+    _config_vars['extra_include_dirs'] = [os.path.abspath('./lib/py-lmdb')]
+
     _ffi = cffi.FFI()
     _ffi.cdef(_CFFI_CDEF)
     _lib = _ffi.verify(_CFFI_VERIFY,
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ LMDB_FORCE_CFFI=1 python setup.py install
py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.
patching file lmdb.h
patching file mdb.c
Using cffi extension.
running install
/home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        By 2025-Oct-31, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
running build
running build_py
creating build/lib.linux-x86_64-pypy311/lmdb
copying lmdb/__main__.py -> build/lib.linux-x86_64-pypy311/lmdb
copying lmdb/cffi.py -> build/lib.linux-x86_64-pypy311/lmdb
copying lmdb/_config.py -> build/lib.linux-x86_64-pypy311/lmdb
copying lmdb/__init__.py -> build/lib.linux-x86_64-pypy311/lmdb
copying lmdb/tool.py -> build/lib.linux-x86_64-pypy311/lmdb
running build_ext
building 'lmdb_cffi' extension
creating build/temp.linux-x86_64-pypy311/home/oberstet/scm/oberstet/py-lmdb/build/lib
creating build/temp.linux-x86_64-pypy311/lmdb/__pycache__
gcc -pthread -DNDEBUG -O2 -fPIC -I/home/oberstet/scm/oberstet/py-lmdb/lib/py-lmdb -I/home/oberstet/scm/oberstet/py-lmdb/.venv/include -I/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/include/pypy3.11 -c /home/oberstet/scm/oberstet/py-lmdb/build/lib/mdb.c -o build/temp.linux-x86_64-pypy311/home/oberstet/scm/oberstet/py-lmdb/build/lib/mdb.o -DHAVE_PATCHED_LMDB=1 -UNDEBUG -w
gcc -pthread -DNDEBUG -O2 -fPIC -I/home/oberstet/scm/oberstet/py-lmdb/lib/py-lmdb -I/home/oberstet/scm/oberstet/py-lmdb/.venv/include -I/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/include/pypy3.11 -c /home/oberstet/scm/oberstet/py-lmdb/build/lib/midl.c -o build/temp.linux-x86_64-pypy311/home/oberstet/scm/oberstet/py-lmdb/build/lib/midl.o -DHAVE_PATCHED_LMDB=1 -UNDEBUG -w
gcc -pthread -DNDEBUG -O2 -fPIC -I/home/oberstet/scm/oberstet/py-lmdb/lib/py-lmdb -I/home/oberstet/scm/oberstet/py-lmdb/.venv/include -I/home/oberstet/pypy-c-jit-186841-96d4b7e66661-linux64/include/pypy3.11 -c lmdb/__pycache__/lmdb_cffi.c -o build/temp.linux-x86_64-pypy311/lmdb/__pycache__/lmdb_cffi.o -DHAVE_PATCHED_LMDB=1 -UNDEBUG -w
gcc -pthread -shared -Wl,-Bsymbolic-functions build/temp.linux-x86_64-pypy311/home/oberstet/scm/oberstet/py-lmdb/build/lib/mdb.o build/temp.linux-x86_64-pypy311/home/oberstet/scm/oberstet/py-lmdb/build/lib/midl.o build/temp.linux-x86_64-pypy311/lmdb/__pycache__/lmdb_cffi.o -o build/lib.linux-x86_64-pypy311/lmdb/lmdb_cffi.pypy311-pp73-x86_64-linux-gnu.so
running install_lib
creating /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/__init__.py -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/lmdb_cffi.pypy311-pp73-x86_64-linux-gnu.so -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/_config.py -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/tool.py -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/__main__.py -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
copying build/lib.linux-x86_64-pypy311/lmdb/cffi.py -> /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb
byte-compiling /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb/__init__.py to __init__.pypy311.pyc
byte-compiling /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb/_config.py to _config.pypy311.pyc
byte-compiling /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb/tool.py to tool.pypy311.pyc
byte-compiling /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb/__main__.py to __main__.pypy311.pyc
byte-compiling /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb/cffi.py to cffi.pypy311.pyc
running install_egg_info
running egg_info
creating lmdb.egg-info
writing lmdb.egg-info/PKG-INFO
writing dependency_links to lmdb.egg-info/dependency_links.txt
writing requirements to lmdb.egg-info/requires.txt
writing top-level names to lmdb.egg-info/top_level.txt
writing manifest file 'lmdb.egg-info/SOURCES.txt'
reading manifest file 'lmdb.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching 'docs/_build'
adding license file 'LICENSE'
writing manifest file 'lmdb.egg-info/SOURCES.txt'
Copying lmdb.egg-info to /home/oberstet/scm/oberstet/py-lmdb/.venv/lib/pypy3.11/site-packages/lmdb-1.7.0.dev0-py3.11.egg-info
running install_scripts
(.venv) oberstet@amd-ryzen5:~/scm/oberstet/py-lmdb$ 
```

