### PR TITLE
Fix: CFFI build now uses relative paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ elif os.getenv('LMDB_PURE') is not None:
     patch_lmdb_source = False
 else:
     print('py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.')
-    extra_sources = ['build/lib/mdb.c', 'build/lib/midl.c']
-    extra_include_dirs += ['build/lib', 'lib/py-lmdb']
+    extra_sources = [os.path.join(os.path.dirname(__file__), 'build/lib/mdb.c'), os.path.join(os.path.dirname(__file__), 'build/lib/midl.c')]
+    extra_include_dirs += [os.path.join(os.path.dirname(__file__), 'build/lib'), os.path.join(os.path.dirname(__file__), 'lib/py-lmdb')]
     extra_compile_args += ['-DHAVE_PATCHED_LMDB=1']
     libraries = []
 

--- a/setup.py
+++ b/setup.py
@@ -81,8 +81,8 @@ elif os.getenv('LMDB_PURE') is not None:
     patch_lmdb_source = False
 else:
     print('py-lmdb: Using bundled liblmdb with py-lmdb patches; override with LMDB_FORCE_SYSTEM=1 or LMDB_PURE=1.')
-    extra_sources = [os.path.abspath(s) for s in ['build/lib/mdb.c', 'build/lib/midl.c']]
-    extra_include_dirs += [os.path.abspath('build/lib'), os.path.abspath('lib/py-lmdb')]
+    extra_sources = ['build/lib/mdb.c', 'build/lib/midl.c']
+    extra_include_dirs += ['build/lib', 'lib/py-lmdb']
     extra_compile_args += ['-DHAVE_PATCHED_LMDB=1']
     libraries = []
 


### PR DESCRIPTION
The CFFI build process was previously using absolute paths to the source and include directories, which caused the resulting wheel to be non-portable.

This commit uses relative paths instead. This ensures that the CFFI build process creates a portable wheel that can be installed on any machine.