### PR TITLE
Fix installing on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -186,7 +186,7 @@ else:
         ext_modules = [lmdb.cffi._ffi.verifier.get_extension()]
     except ImportError:
         sys.stderr.write('Could not import lmdb; ensure cffi is installed!\n')
-        sys.exit(1)
+        ext_modules = []
 
 def grep_version():
     path = os.path.join(os.path.dirname(__file__), 'lmdb/__init__.py')


### PR DESCRIPTION
Remove the incorrect assumption that PyPy does not use the extension modules -- it needs them just the same as other Python implementations. Make the `cffi` dependency specific to CPython, as it is vendored in PyPy.  Fail if CFFI cannot be imported, as otherwise broken package will be installed.

Fixes #397