### PR TITLE
Fix installing and running on PyPy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,12 @@ else:
     print('Using cffi extension.')
     install_requires = ['cffi>=0.8; implementation_name=="cpython"']
     print('Using cffi, building extension module.')
+    # Ensure the source directory is on sys.path so that `import lmdb.cffi`
+    # works in build-isolated environments where pip runs setup.py from a
+    # temporary directory.
+    _source_dir = os.path.dirname(os.path.abspath(__file__))
+    if _source_dir not in sys.path:
+        sys.path.insert(0, _source_dir)
     try:
         import lmdb.cffi
         ext_modules = [lmdb.cffi._ffi.verifier.get_extension()]


### PR DESCRIPTION
## Summary

- Remove incorrect assumption that PyPy does not need the CFFI extension module built — it needs the compiled `.so` just like CPython (from #398 by @mgorny)
- Make `cffi` a runtime dependency only for CPython, since PyPy vendors it
- Fix `import lmdb.cffi` failing during build-isolated `pip install` by ensuring the source directory is on `sys.path`

Without these fixes, `pip install lmdb` on PyPy produces a pure-Python wheel (`py3-none-any`) missing the compiled extension. At runtime, `import lmdb` then tries to dynamically compile via CFFI, which fails on machines without the LMDB C source files.

Fixes #397. Supersedes #398.

## Test plan

- [x] PyPy isolated `pip install` produces platform-specific wheel with `.so`
- [x] PyPy import + basic put/get works from outside source tree with build dir absent
- [x] PyPy test suite: 192 passed
- [x] CPython C extension path: works
- [x] CPython CFFI path (`LMDB_FORCE_CFFI=1`): works

🤖 Generated with [Claude Code](https://claude.com/claude-code)