### PR TITLE
Prevent opening the same LMDB environment twice

### DIFF
--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -95,6 +95,10 @@ UnicodeType = getattr(__builtin__, 'unicode', str)
 BytesType = getattr(__builtin__, 'bytes', str)
 
 O_0755 = int('0755', 8)
+
+# Global set of canonical paths for open environments, to prevent
+# opening the same environment twice in one process (causes segfaults).
+_open_env_paths = set()
 O_0111 = int('0111', 8)
 EMPTY_BYTES = UnicodeType().encode()
 
@@ -749,6 +753,11 @@ class Environment(object):
                 if e.errno != errno.EEXIST:
                     raise
 
+        self._open_path = os.path.realpath(path)
+        if self._open_path in _open_env_paths:
+            raise Error("The environment %r is already open in this process."
+                        % (path,))
+
         flags = _lib.MDB_NOTLS
         if not subdir:
             flags |= _lib.MDB_NOSUBDIR
@@ -791,6 +800,7 @@ class Environment(object):
             )
 
         self._dbs = {None: self._db}
+        _open_env_paths.add(self._open_path)
 
     def __enter__(self):
         return self
@@ -856,6 +866,11 @@ class Environment(object):
 
             _lib.mdb_env_close(self._env)
             self._env = _invalid
+
+            open_path = getattr(self, '_open_path', None)
+            if open_path:
+                _open_env_paths.discard(open_path)
+                self._open_path = None
 
     def path(self):
         """Directory path or file name prefix where this environment is

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -97,6 +97,8 @@ static PyObject *py_int_max;
 static PyObject *py_size_max;
 /** lmdb.Error type. */
 static PyObject *Error;
+/** Global set of canonical paths for open environments. */
+static PyObject *open_env_paths;
 
 /** Typedefs and forward declarations. */
 static PyTypeObject PyDatabase_Type;
@@ -175,6 +177,8 @@ struct EnvObject {
     pid_t pid;
     /** 1 if a write transaction is active on this environment. */
     int has_write_txn;
+    /** Resolved path used to track this env in open_env_paths. */
+    PyObject *open_path;
 };
 
 /** TransObject.flags bitfield values. */
@@ -1190,6 +1194,11 @@ env_clear(EnvObject *self)
         Py_END_ALLOW_THREADS
         self->env = NULL;
     }
+
+    if(self->open_path) {
+        PySet_Discard(open_env_paths, self->open_path);
+        Py_CLEAR(self->open_path);
+    }
     return 0;
 }
 
@@ -1287,6 +1296,7 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->main_db = NULL;
     self->env = NULL;
     self->spare_txn = NULL;
+    self->open_path = NULL;
     self->max_spare_txns = arg.max_spare_txns;
     self->pid = getpid();
     self->has_write_txn = 0;
@@ -1321,6 +1331,45 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             PyErr_SetFromErrnoWithFilename(PyExc_OSError, fspath);
             goto fail;
         }
+    }
+
+    {
+        PyObject *os_path = PyImport_ImportModule("os.path");
+        PyObject *realpath_func;
+        PyObject *resolved;
+
+        if(! os_path) {
+            goto fail;
+        }
+        realpath_func = PyObject_GetAttrString(os_path, "realpath");
+        Py_DECREF(os_path);
+        if(! realpath_func) {
+            goto fail;
+        }
+        resolved = PyObject_CallFunctionObjArgs(realpath_func, arg.path, NULL);
+        Py_DECREF(realpath_func);
+        if(! resolved) {
+            goto fail;
+        }
+
+        /* Normalize to a string for consistent set membership. */
+        if(PyBytes_Check(resolved)) {
+            PyObject *tmp = PyUnicode_DecodeFSDefault(PyBytes_AS_STRING(resolved));
+            Py_DECREF(resolved);
+            if(! tmp) {
+                goto fail;
+            }
+            resolved = tmp;
+        }
+
+        if(PySet_Contains(open_env_paths, resolved)) {
+            PyErr_Format(Error,
+                "The environment '%s' is already open in this process.",
+                fspath);
+            Py_DECREF(resolved);
+            goto fail;
+        }
+        self->open_path = resolved;  /* steal reference */
     }
 
     flags = MDB_NOTLS;
@@ -1366,6 +1415,9 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->main_db = txn_db_from_name(self, NULL, 0);
     if(self->main_db) {
         self->valid = 1;
+        if(PySet_Add(open_env_paths, self->open_path)) {
+            goto fail;
+        }
         DEBUG("EnvObject '%s' opened at %p", fspath, self)
         return (PyObject *) self;
     }
@@ -4146,6 +4198,10 @@ MODINIT_NAME(void)
     }
 
     if(! ((__all__ = PyList_New(0)))) {
+        MOD_RETURN(NULL);
+    }
+
+    if(! ((open_env_paths = PySet_New(NULL)))) {
         MOD_RETURN(NULL);
     }
 

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -120,10 +120,12 @@ class OpenTest(unittest.TestCase):
 
     def test_subdir_true_exist_nocreate(self):
         path, env = testlib.temp_env()
+        env.close()
         assert lmdb.open(path, subdir=True, create=False).path() == path
 
     def test_subdir_true_exist_create(self):
         path, env = testlib.temp_env()
+        env.close()
         assert lmdb.open(path, subdir=True, create=True).path() == path
 
     def test_readonly_false(self):
@@ -144,6 +146,7 @@ class OpenTest(unittest.TestCase):
 
     def test_readonly_true_exist(self):
         path, env = testlib.temp_env()
+        env.close()
         env2 = lmdb.open(path, readonly=True)
         assert env2.path() == path
         # Attempting a write txn should fail.
@@ -151,6 +154,17 @@ class OpenTest(unittest.TestCase):
             lambda: env2.begin(write=True))
         # Flag should be set.
         assert env2.flags()['readonly']
+
+    def test_open_same_path_twice(self):
+        path, env = testlib.temp_env()
+        self.assertRaises(lmdb.Error,
+            lambda: lmdb.open(path))
+
+    def test_open_same_path_after_close(self):
+        path, env = testlib.temp_env()
+        env.close()
+        env2 = lmdb.open(path)
+        env2.close()
 
     def test_metasync(self):
         for flag in True, False:
@@ -575,12 +589,7 @@ class OtherMethodsTest(unittest.TestCase):
         rc = env.reader_check()
         assert rc == 0
 
-        # We need to open a separate env since Transaction.abort() always calls
-        # reset for a read-only txn, the actual abort doesn't happen until
-        # __del__, when Transaction discovers there is no room for it on the
-        # freelist.
-        env1 = lmdb.open(path)
-        txn1 = env1.begin()
+        txn1 = env.begin()
         assert env.readers() != NO_READERS
         assert env.reader_check() == 0
 
@@ -593,8 +602,10 @@ class OtherMethodsTest(unittest.TestCase):
         assert env.reader_check() == 0
         assert env.readers() != NO_READERS
 
+        # abort() only resets a read-only txn; the reader slot is freed
+        # when the TransObject is deallocated.
         txn1.abort()
-        env1.close()
+        del txn1
         assert env.readers() == NO_READERS
 
         env.close()


### PR DESCRIPTION
## Summary
- Track open environment paths in a global set to prevent opening the same LMDB environment twice in one process, which causes segfaults (#230)
- Uses `os.path.realpath()` to canonicalize paths so relative/symlinked duplicates are caught
- Implemented in both the CPython C extension and CFFI backend
- Path is removed from the set on `close()`/dealloc, so reopening after close works normally

## Test plan
- [x] Added `test_open_same_path_twice` — verifies `lmdb.Error` is raised
- [x] Added `test_open_same_path_after_close` — verifies reopen after close works
- [x] All 203 tests pass (CPython backend, Linux)
- [x] All 70 env tests pass (CFFI backend, Linux)
- [x] All 194 tests pass (CPython backend, Windows)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)