### PR TITLE
Fix ReadTheDocs build failing to render API docs

### DIFF
--- a/lmdb/__init__.py
+++ b/lmdb/__init__.py
@@ -30,6 +30,9 @@ import sys
 def _reading_docs():
     # Hack: disable speedups while testing or reading docstrings. Don't check
     # for basename for embedded python - variable 'argv' does not exists there or is empty.
+    if os.environ.get('READTHEDOCS'):
+        return True
+
     if not(hasattr(sys, 'argv')) or not sys.argv:
         return False
 
@@ -37,13 +40,13 @@ def _reading_docs():
     return any(x in basename for x in ('sphinx-build', 'pydoc'))
 
 try:
-    if _reading_docs() or os.getenv('LMDB_FORCE_CFFI') is not None:
+    if os.getenv('LMDB_FORCE_CFFI') is not None:
         raise ImportError
     from lmdb.cpython import *
     from lmdb.cpython import open
     from lmdb.cpython import __all__
 except ImportError:
-    if (not _reading_docs()) and os.getenv('LMDB_FORCE_CPYTHON') is not None:
+    if os.getenv('LMDB_FORCE_CPYTHON') is not None:
         raise
     from lmdb.cffi import *
     from lmdb.cffi import open

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -367,7 +367,10 @@ if not lmdb._reading_docs():
         'libraries': []
     }
 
-    _have_patched_lmdb = '-DHAVE_PATCHED_LMDB=1' in _config.CONFIG['extra_compile_args']  # type: ignore
+    _have_patched_lmdb = (
+        _config is not None and
+        '-DHAVE_PATCHED_LMDB=1' in _config.CONFIG['extra_compile_args']  # type: ignore
+    )
 
     if _have_patched_lmdb:
         _CFFI_CDEF += _CFFI_CDEF_PATCHED


### PR DESCRIPTION
## Summary
- Stop skipping the C extension import during sphinx/pydoc builds. Previously `_reading_docs()` forced a fallback to CFFI even when the C extension was available, making lmdb non-functional during doc generation (e.g. a sphinx extension that opens an lmdb database). Now the C extension is always tried first.
- Add `READTHEDOCS` env var detection to `_reading_docs()`. RTD invokes sphinx as `python -m sphinx`, so `sys.argv[0]` is `__main__.py` rather than `sphinx-build`.
- Make `cffi.py`'s `_config.CONFIG` access defensive against `_config` being `None`.

Fixes #414, fixes #172

## Test plan
- [x] `python -m sphinx -T -b html` builds docs with no warnings and all sections rendered
- [x] Normal `import lmdb` still uses the C extension
- [x] `LMDB_FORCE_CFFI=1` test suite passes
- [x] `READTHEDOCS=True LMDB_FORCE_CFFI=1` correctly falls back to CFFI doc-reading mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)