### PR TITLE
Enable sparse files on Windows to avoid map_size preallocation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -583,10 +583,13 @@ GiB) when opening the environment:
 
 .. caution::
 
-    On filesystems that don't support sparse files — notably Windows (NTFS)
-    and older macOS (HFS+) — the full ``map_size`` may be preallocated on
-    disk.  On such systems, choose a map size closer to the expected data size
-    and use ``set_mapsize()`` to grow as needed.
+    On filesystems that don't support sparse files — notably older macOS
+    (HFS+) — the full ``map_size`` may be preallocated on disk.  On such
+    systems, choose a map size closer to the expected data size and use
+    ``set_mapsize()`` to grow as needed.
+
+    py-lmdb enables sparse files on Windows (NTFS) automatically, so large
+    ``map_size`` values do not waste disk space there.
 
 **Resize at runtime with set_mapsize()**
 

--- a/lib/py-lmdb/win32-sparse-file.patch
+++ b/lib/py-lmdb/win32-sparse-file.patch
@@ -1,0 +1,20 @@
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -4404,6 +4404,16 @@
+
+ 	if (fd == INVALID_HANDLE_VALUE)
+ 		rc = ErrCode();
++#ifdef _WIN32
++	else if (which == MDB_O_RDWR) {
++		/* Mark the data file as sparse so the OS does not preallocate
++		 * the full map_size on disk.  Silently ignored on filesystems
++		 * that do not support sparse files (e.g. FAT32). */
++		DWORD dw;
++		(void)DeviceIoControl(fd, FSCTL_SET_SPARSE, NULL, 0,
++			NULL, 0, &dw, NULL);
++	}
++#endif
+ #ifndef _WIN32
+ 	else {
+ 		if (which != MDB_O_RDONLY && which != MDB_O_RDWR) {

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ if patch_lmdb_source:
         'validate-nodedsz-cursor-put',
         'validate-md-depth',
         'validate-md-root',
+        'win32-sparse-file',
     ]
 
     if sys.platform.startswith('win'):


### PR DESCRIPTION
## Summary

- On Windows (NTFS), LMDB's data file was preallocated to the full `map_size` because NTFS doesn't use sparse files by default. This forced users to choose small map sizes or waste disk space.
- Adds a patch that calls `FSCTL_SET_SPARSE` on the data file after `CreateFileW` in `mdb_fopen`. Only targets `MDB_O_RDWR` (writable data files). Silently ignored on filesystems that don't support sparse files (e.g. FAT32).
- Adapted from the experimental `win32-sparse-patch` branch (2015, openldap-devel) for the current LMDB code structure which uses a centralized `mdb_fopen` helper.

## Backward compatibility

`FSCTL_SET_SPARSE` on an existing non-sparse file marks it sparse going forward — existing allocated regions are unchanged. No data loss, no format change.

## Test plan

- [x] Patch applies cleanly via both unix `patch` and `patch_ng` (Windows)
- [x] Builds and passes all tests on Linux (356 passed)
- [x] Builds and passes all tests on Windows (215 passed, 4 skipped)
- [x] Verified with `fsutil sparse queryflag` that a 1 GiB `map_size` env reports "This file is set as sparse"
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)