### PR TITLE
Declare python_requires>=3.9 so pip skips unsupported Pythons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -268,6 +268,7 @@ setup(
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",
     ],
+    python_requires='>=3.9',
     ext_package='lmdb',
     ext_modules=ext_modules,
     install_requires=install_requires,


### PR DESCRIPTION
## Summary

- Add `python_requires='>=3.9'` to `setup()` in setup.py
- Without this, pip on Python 2 (or 3.8 and below) attempts to install the latest version, which fails at build time
- The metadata tells pip's dependency resolver to skip incompatible versions entirely

One-line change. Verified `Requires-Python: >=3.9` appears in installed package metadata.

## Test plan

- [x] Build succeeds
- [x] All 356 tests pass
- [x] `importlib.metadata.metadata('lmdb')['Requires-Python']` returns `>=3.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)