### PR TITLE
Fix crashes on OOM in cpython.c error paths

### DIFF
--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -1216,6 +1216,8 @@ db_flags(DbObject *self, PyObject *args, PyObject *kwds)
     }
 
     dct = PyDict_New();
+    if(! dct)
+        return NULL;
     f = self->flags;
     dict_set_bool(dct, "reverse_key", f & MDB_REVERSEKEY);
     dict_set_bool(dct, "dupsort", f & MDB_DUPSORT);
@@ -1825,6 +1827,8 @@ env_flags(EnvObject *self, PyObject *Py_UNUSED(ignored))
     }
 
     dct = PyDict_New();
+    if(! dct)
+        return NULL;
     dict_set_bool(dct, "subdir", !(flags & MDB_NOSUBDIR));
     dict_set_bool(dct, "readonly", flags & MDB_RDONLY);
     dict_set_bool(dct, "metasync", !(flags & MDB_NOMETASYNC));
@@ -2608,6 +2612,10 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
     val_size = arg.dupfixed_bytes;
     if (!arg.keyfixed){ /* Init list */
         pylist = PyList_New(0);
+        if(! pylist) {
+            Py_DECREF(iter);
+            return NULL;
+        }
     }
     first = true;
     while((item = PyIter_Next(iter))) {
@@ -2716,7 +2724,7 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
                             } else {
                                 Py_XDECREF(val);
                                 Py_XDECREF(tup);
-                                Py_DECREF(key);
+                                Py_XDECREF(key);
                                 goto failiter;
                             }
                         }


### PR DESCRIPTION
## Summary
Audit of cpython.c found four error-path crashes that could occur under memory pressure:

- `cursor_get_multi`: `Py_DECREF(key)` on a NULL key (when `obj_from_val` fails) in the dupfixed branch — changed to `Py_XDECREF`
- `cursor_get_multi`: `PyList_New(0)` result not NULL-checked, leading to `PyList_Append` on NULL
- `db_flags` / `env_flags`: `PyDict_New()` result not NULL-checked, leading to `PyDict_SetItemString` on NULL via `dict_set_bool`

All four are OOM-only error paths — no normal-execution leaks were found.

## Test plan
- [x] Full test suite passes (356 tests)
- [x] Builds clean with `LMDB_MAINTAINER=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)