### PR TITLE
fix `__all__` in type stubs

### DIFF
--- a/lmdb/__init__.pyi
+++ b/lmdb/__init__.pyi
@@ -268,4 +268,37 @@ class Cursor:
         self, k: Buffer, reverse: bool
     ) -> Iterator[tuple[_Val, _Val]]: ...
 
-__all__: list[str]
+__all__ = [
+    "Cursor",
+    "Environment",
+    "Transaction",
+    "_Database",
+    "enable_drop_gil",
+    "version",
+    "BadDbiError",
+    "BadRslotError",
+    "BadTxnError",
+    "BadValsizeError",
+    "CorruptedError",
+    "CursorFullError",
+    "DbsFullError",
+    "DiskError",
+    "Error",
+    "IncompatibleError",
+    "InvalidError",
+    "InvalidParameterError",
+    "KeyExistsError",
+    "LockError",
+    "MapFullError",
+    "MapResizedError",
+    "MemoryError",
+    "NotFoundError",
+    "PageFullError",
+    "PageNotFoundError",
+    "PanicError",
+    "ReadersFullError",
+    "ReadonlyError",
+    "TlsFullError",
+    "TxnFullError",
+    "VersionMismatchError",
+]


### PR DESCRIPTION
The `__all__: list[str]` confuses static type-checkers, because if there's a `.pyi`, then that's all they look at, so they wouldn't know what the publically exports in the `__all__` actually are. This can be problematic for e.g. IDE import completion or API indexing. (see e.g. https://jorenham.github.io/typestats/dashboard/report/#lmdb)

According to the [Python typing spec](https://typing.python.org/en/latest/guides/writing_stubs.html#all):

> A stub file should contain an `__all__` variable if and only if it is also present at runtime. In that case, the contents of `__all__` should be identical in the stub and at runtime. If the runtime dynamically adds or removes elements (for example if certain functions are only available on some system configurations), include all possible elements in the stubs.

Anyway, long story short: this fixes `__all__` so that it conforms to the typing spec and should make it easier for static type-checkers to index  `lmdb`.