### PR TITLE
Remove Python 2 remnants

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,7 +258,7 @@ texinfo_documents = [
 
 import sys
 
-class Mock(object):
+class Mock:
     def __init__(self, *args, **kwargs):
         pass
 

--- a/examples/dirtybench-gdbm.py
+++ b/examples/dirtybench-gdbm.py
@@ -24,7 +24,7 @@ def x():
         os.unlink(DB_PATH)
 
     t0 = now()
-    words = set(file('/usr/share/dict/words').readlines())
+    words = set(open('/usr/share/dict/words').readlines())
     words.update([w.upper() for w in words])
     words.update([w[::-1] for w in words])
     words.update([w[::-1].upper() for w in words])
@@ -34,9 +34,9 @@ def x():
     words = list(words)
     alllen = sum(len(w) for w in words)
     avglen = alllen  / len(words)
-    print 'permutate %d words avglen %d took %.2fsec' % (len(words), avglen, now()-t0)
+    print('permutate %d words avglen %d took %.2fsec' % (len(words), avglen, now()-t0))
 
-    getword = iter(words).next
+    getword = iter(words).__next__
 
     env = gdbm.open(DB_PATH, 'c')
 
@@ -45,7 +45,7 @@ def x():
     last = t0
     while run:
         try:
-            for _ in xrange(50000):
+            for _ in range(50000):
                 word = getword()
                 env[word] = big or word
         except StopIteration:
@@ -53,68 +53,68 @@ def x():
 
         t1 = now()
         if (t1 - last) > 2:
-            print '%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0))
+            print('%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0)))
             last = t1
 
     t1 = now()
-    print 'done all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0))
+    print('done all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0)))
     last = t1
 
-    print
-    print
+    print()
+    print()
 
     t0 = now()
     lst = sum(env[k] and 1 for k in env.keys())
     t1 = now()
-    print 'enum %d (key, value) pairs took %.2f sec' % ((lst), t1-t0)
+    print('enum %d (key, value) pairs took %.2f sec' % ((lst), t1-t0))
 
     t0 = now()
     lst = sum(1 or env[k] for k in reversed(env.keys()))
     t1 = now()
-    print 'reverse enum %d (key, value) pairs took %.2f sec' % ((lst), t1-t0)
+    print('reverse enum %d (key, value) pairs took %.2f sec' % ((lst), t1-t0))
 
     t0 = now()
     for word in words:
         env[word]
     t1 = now()
-    print 'rand lookup all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0))
+    print('rand lookup all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0)))
 
     t0 = now()
     for word in words:
         hash(env[word])
     t1 = now()
-    print 'per txn rand lookup+hash all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0))
+    print('per txn rand lookup+hash all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0)))
 
     t0 = now()
     for word in words:
         hash(env[word])
     t1 = now()
-    print 'rand lookup+hash all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0))
+    print('rand lookup+hash all keys %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0)))
 
     t0 = now()
     for word in words:
         env[word]
     t1 = now()
-    print 'rand lookup all buffers %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0))
+    print('rand lookup all buffers %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0)))
 
     t0 = now()
     for word in words:
         hash(env[word])
     t1 = now()
-    print 'rand lookup+hash all buffers %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0))
+    print('rand lookup+hash all buffers %.2f sec (%d/sec)' % (t1-t0, lst/(t1-t0)))
 
 
     #
     # get+put
     #
 
-    getword = iter(sorted(words)).next
+    getword = iter(sorted(words)).__next__
     run = True
     t0 = now()
     last = t0
     while run:
         try:
-            for _ in xrange(50000):
+            for _ in range(50000):
                 word = getword()
                 old = env[word]
                 env[word] = word
@@ -123,11 +123,11 @@ def x():
 
         t1 = now()
         if (t1 - last) > 2:
-            print '%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0))
+            print('%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0)))
             last = t1
 
     t1 = now()
-    print 'get+put all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0))
+    print('get+put all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0)))
     last = t1
 
 
@@ -135,13 +135,13 @@ def x():
     # REPLACE
     #
 
-    getword = iter(sorted(words)).next
+    getword = iter(sorted(words)).__next__
     run = True
     t0 = now()
     last = t0
     while run:
         try:
-            for _ in xrange(50000):
+            for _ in range(50000):
                 word = getword()
                 old = env[word]
         except StopIteration:
@@ -149,11 +149,11 @@ def x():
 
         t1 = now()
         if (t1 - last) > 2:
-            print '%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0))
+            print('%.2fs (%d/sec)' % (t1-t0, len(words)/(t1-t0)))
             last = t1
 
     t1 = now()
-    print 'replace all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0))
+    print('replace all %d in %.2fs (%d/sec)' % (len(words), t1-t0, len(words)/(t1-t0)))
     last = t1
 
 

--- a/examples/dirtybench.py
+++ b/examples/dirtybench.py
@@ -58,14 +58,14 @@ def x():
     words.update([w.upper() for w in words])
     words.update([w[::-1] for w in words])
     words.update([w[::-1].upper() for w in words])
-    words.update(['-'.join(w) for w in words])
+    words.update([b'-'.join(w) for w in words])
     #words.update(['+'.join(w) for w in words])
     #words.update(['/'.join(w) for w in words])
     words = list(words)
     alllen = sum(len(w) for w in words)
     avglen = alllen  / len(words)
-    print 'permutate %d words avglen %d took %.2fsec' % (len(words), avglen, now()-t0)
-    print 'DB_PATH:', DB_PATH
+    print('permutate %d words avglen %d took %.2fsec' % (len(words), avglen, now()-t0))
+    print('DB_PATH:', DB_PATH)
 
     words_sorted = sorted(words)
     items = [(w, big or w) for w in words]
@@ -83,13 +83,13 @@ def x():
 
 
     st = env.stat()
-    print
-    print 'stat:', st
-    print 'k+v size %.2fkb avg %d, on-disk size: %.2fkb avg %d' %\
+    print()
+    print('stat:', st)
+    print('k+v size %.2fkb avg %d, on-disk size: %.2fkb avg %d' %\
         ((2*alllen) / 1024., (2*alllen)/len(words),
          (st['psize'] * st['leaf_pages']) / 1024.,
-         (st['psize'] * st['leaf_pages']) / len(words))
-    print
+         (st['psize'] * st['leaf_pages']) / len(words)))
+    print()
 
 
     @case('enum (key, value) pairs')
@@ -110,7 +110,7 @@ def x():
             return sum(1 for _ in txn.cursor())
 
 
-    print
+    print()
 
 
     @case('rand lookup')
@@ -162,7 +162,7 @@ def x():
         return len(words)
 
 
-    print
+    print()
 
 
     @case('get+put')
@@ -201,7 +201,7 @@ def x():
         return len(words)
 
 
-    print
+    print()
 
 
     env = reopen_env()
@@ -258,7 +258,7 @@ def x():
         return len(words)
 
 
-    print
+    print()
 
 
     env = reopen_env()
@@ -288,12 +288,12 @@ def x():
         return len(words)
 
 
-    print
+    print()
     st = env.stat()
-    print 'stat:', st
-    print 'k+v size %.2fkb avg %d, on-disk size: %.2fkb avg %d' %\
+    print('stat:', st)
+    print('k+v size %.2fkb avg %d, on-disk size: %.2fkb avg %d' %\
         ((2*alllen) / 1024., (2*alllen)/len(words),
          (st['psize'] * st['leaf_pages']) / 1024.,
-         (st['psize'] * st['leaf_pages']) / len(words))
+         (st['psize'] * st['leaf_pages']) / len(words)))
 
 x()

--- a/examples/keystore/interfaces.py
+++ b/examples/keystore/interfaces.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import zope.interface
 
 

--- a/examples/keystore/lmdb.py
+++ b/examples/keystore/lmdb.py
@@ -1,5 +1,3 @@
-
-from __future__ import absolute_import
 import operator
 
 import twisted.internet.defer
@@ -9,7 +7,7 @@ import zope.interface
 import keystore.interfaces
 
 
-class LmdbKeyStoreSync(object):
+class LmdbKeyStoreSync:
     zope.interface.implements(keystore.interfaces.IKeyStoreSync)
     cursor = None
 
@@ -67,7 +65,7 @@ def _writer_task(env, func):
         return func(sync)
 
 
-class LmdbKeyStore(object):
+class LmdbKeyStore:
     zope.interface.implements(keystore.interfaces.IKeyStore)
 
     def __init__(self, reactor, pool, env):
@@ -89,7 +87,7 @@ class LmdbKeyStore(object):
     def _get_forward(self, sync, key, count, getter):
         positioned = sync.seek(key)
         out = []
-        for x in xrange(count):
+        for x in range(count):
             if not positioned:
                 break
             out.append(getter(sync))
@@ -101,7 +99,7 @@ class LmdbKeyStore(object):
         positioned = sync.seek(key)
         if not positioned:
             positioned = sync.last()
-        for x in xrange(count):
+        for x in range(count):
             if not positioned:
                 break
             out.append(sync.key)

--- a/examples/keystore/main.py
+++ b/examples/keystore/main.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import webbrowser
 
 import twisted.internet.reactor

--- a/examples/keystore/web.py
+++ b/examples/keystore/web.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import twisted.python.failure
 import twisted.python.log
 import twisted.web.http
@@ -7,14 +6,14 @@ import twisted.web.resource
 import twisted.web.server
 
 
-class Response(object):
+class Response:
     def __init__(self, body=None, headers=None, status=None):
         self.body = body
         self.headers = headers or {}
         self.status = status
 
 
-class DeferrableResourceRender(object):
+class DeferrableResourceRender:
     def __init__(self, resource_, request):
         self.resource = resource_
         self.request = request

--- a/examples/keystore/webapi.py
+++ b/examples/keystore/webapi.py
@@ -1,5 +1,4 @@
 
-from __future__ import absolute_import
 import pkg_resources
 import keystore.web
 import twisted.web.server

--- a/examples/nastybench.py
+++ b/examples/nastybench.py
@@ -10,19 +10,19 @@ import tempfile
 import lmdb
 
 
-val = ' ' * 100
+val = b' ' * 100
 MAX_KEYS = int(1e6)
 
 t0 = time()
 
-urandom = file('/dev/urandom', 'rb', 1048576).read
+urandom = open('/dev/urandom', 'rb', 1048576).read
 
 keys = set()
 while len(keys) < MAX_KEYS:
-    for _ in xrange(min(1000, MAX_KEYS - len(keys))):
+    for _ in range(min(1000, MAX_KEYS - len(keys))):
         keys.add(urandom(16))
 
-print 'make %d keys in %.2fsec' % (len(keys), time() - t0)
+print('make %d keys in %.2fsec' % (len(keys), time() - t0))
 keys = list(keys)
 
 if os.path.exists('/ram'):
@@ -36,23 +36,23 @@ if os.path.exists(DB_PATH):
 env = lmdb.open(DB_PATH, map_size=1048576 * 1024,
     metasync=False, sync=False, map_async=True)
 
-nextkey = iter(keys).next
+nextkey = iter(keys).__next__
 run = True
 while run:
     with env.begin(write=True) as txn:
         try:
-            for _ in xrange(10000):
+            for _ in range(10000):
                 txn.put(nextkey(), val)
         except StopIteration:
             run = False
 
 d = time() - t0
 env.sync(True)
-print 'insert %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys) / d)
+print('insert %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys) / d))
 
 
 
-nextkey = iter(keys).next
+nextkey = iter(keys).__next__
 t0 = time()
 
 with env.begin() as txn:
@@ -63,10 +63,10 @@ with env.begin() as txn:
         pass
 
 d = time() - t0
-print 'random lookup %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d)
+print('random lookup %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d))
 
 
-nextkey = iter(keys).next
+nextkey = iter(keys).__next__
 t0 = time()
 
 with env.begin(buffers=True) as txn:
@@ -77,10 +77,10 @@ with env.begin(buffers=True) as txn:
         pass
 
 d = time() - t0
-print 'random lookup %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d)
+print('random lookup %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d))
 
 
-nextkey = iter(keys).next
+nextkey = iter(keys).__next__
 t0 = time()
 
 with env.begin(buffers=True) as txn:
@@ -91,15 +91,15 @@ with env.begin(buffers=True) as txn:
         pass
 
 d = time() - t0
-print 'random lookup+hash %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d)
+print('random lookup+hash %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d))
 
 
 
-nextkey = iter(keys).next
+nextkey = iter(keys).__next__
 t0 = time()
 
 with env.begin(buffers=True) as txn:
-    nextrec = txn.cursor().iternext().next
+    nextrec = txn.cursor().iternext().__next__
     try:
         while 1:
             nextrec()
@@ -107,4 +107,4 @@ with env.begin(buffers=True) as txn:
         pass
 
 d = time() - t0
-print 'seq read %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d)
+print('seq read %d buffers in %.2fsec (%d/sec)' % (len(keys), d, len(keys)/d))

--- a/examples/parabench.py
+++ b/examples/parabench.py
@@ -37,24 +37,24 @@ def open_env():
 
 def make_keys():
     t0 = time.time()
-    urandom = file('/dev/urandom', 'rb', 1048576).read
+    urandom = open('/dev/urandom', 'rb', 1048576).read
 
     keys = set()
     while len(keys) < MAX_KEYS:
-        for _ in xrange(min(1000, MAX_KEYS - len(keys))):
+        for _ in range(min(1000, MAX_KEYS - len(keys))):
             keys.add(urandom(16))
 
-    print 'make %d keys in %.2fsec' % (len(keys), time.time() - t0)
+    print('make %d keys in %.2fsec' % (len(keys), time.time() - t0))
     keys = list(keys)
 
-    nextkey = iter(keys).next
+    nextkey = iter(keys).__next__
     run = True
-    val = ' ' * 100
+    val = b' ' * 100
     env = open_env()
     while run:
         with env.begin(write=True) as txn:
             try:
-                for _ in xrange(10000):
+                for _ in range(10000):
                     txn.put(nextkey(), val)
             except StopIteration:
                 run = False
@@ -62,7 +62,7 @@ def make_keys():
     d = time.time() - t0
     env.sync(True)
     env.close()
-    print 'insert %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys) / d)
+    print('insert %d keys in %.2fsec (%d/sec)' % (len(keys), d, len(keys) / d))
 
 
 if 'drop' in sys.argv and os.path.exists(DB_PATH):
@@ -89,7 +89,7 @@ def run(idx):
 
     while 1:
         with env.begin() as txn:
-            nextkey = iter(k).next
+            nextkey = iter(k).__next__
             try:
                 while 1:
                     hash(txn.get(nextkey()))
@@ -100,10 +100,10 @@ def run(idx):
 
 
 nproc = int(sys.argv[1])
-arr = multiprocessing.Array('L', xrange(nproc))
-for x in xrange(nproc):
+arr = multiprocessing.Array('L', range(nproc))
+for x in range(nproc):
     arr[x] = 0
-procs = [multiprocessing.Process(target=run, args=(x,)) for x in xrange(nproc)]
+procs = [multiprocessing.Process(target=run, args=(x,)) for x in range(nproc)]
 [p.start() for p in procs]
 
 
@@ -112,5 +112,5 @@ while True:
     time.sleep(2)
     d = time.time() - t0
     lk = sum(arr)
-    print 'lookup %d keys in %.2fsec (%d/sec)' % (lk, d, lk / d)
+    print('lookup %d keys in %.2fsec (%d/sec)' % (lk, d, lk / d))
 

--- a/lmdb/__main__.py
+++ b/lmdb/__main__.py
@@ -18,7 +18,5 @@
 # Additional information about OpenLDAP can be obtained at
 # <http://www.openldap.org/>.
 
-# Hack to support Python >=v2.6 'python -mlmdb'
-from __future__ import absolute_import
 import lmdb.tool
 lmdb.tool.main()

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -539,9 +539,6 @@ class Some_LMDB_Resource_That_Was_Deleted_Or_Closed:
     of a native handle to ensure the handle is still valid prior to calling
     LMDB, or doing no crash-safety checking at all.
     """
-    def __nonzero__(self):
-        return 0
-
     def __bool__(self):
         return False
 

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -26,9 +26,6 @@ CPython/CFFI wrapper for OpenLDAP's "Lightning" MDB database.
 Please see https://lmdb.readthedocs.io/
 """
 
-from __future__ import absolute_import
-from __future__ import with_statement
-
 import errno
 import inspect
 import os
@@ -38,11 +35,6 @@ import threading
 is_win32 = sys.platform == 'win32'
 if is_win32:
     import msvcrt
-
-try:
-    import __builtin__
-except ImportError:
-    import builtins as __builtin__  # type: ignore
 
 import lmdb
 try:
@@ -90,17 +82,13 @@ __all__ += [
 ]
 
 
-# Handle moronic Python 3 mess.
-UnicodeType = getattr(__builtin__, 'unicode', str)
-BytesType = getattr(__builtin__, 'bytes', str)
-
 O_0755 = int('0755', 8)
 
 # Global set of canonical paths for open environments, to prevent
 # opening the same environment twice in one process (causes segfaults).
 _open_env_paths = set()
 O_0111 = int('0111', 8)
-EMPTY_BYTES = UnicodeType().encode()
+EMPTY_BYTES = b""
 
 
 # Cached process ID for fork detection, mirroring cpython.c.
@@ -540,7 +528,7 @@ def _error(what, rc):
     `rc`, using :py:class:`Error` if no better class exists."""
     return _error_map.get(rc, Error)(what, rc)
 
-class Some_LMDB_Resource_That_Was_Deleted_Or_Closed(object):
+class Some_LMDB_Resource_That_Was_Deleted_Or_Closed:
     """We need this because CFFI on PyPy treats None as cffi.NULL, instead of
     throwing an exception it feeds LMDB null pointers. That means simply
     replacing native handles with None during _invalidate() will cause NULL
@@ -598,7 +586,7 @@ def version(subpatch=False):
             _lib.MDB_VERSION_PATCH)
 
 
-class Environment(object):
+class Environment:
     """
     Structure for a database environment. An environment may contain multiple
     databases, all residing in the same shared-memory map and underlying disk
@@ -793,7 +781,7 @@ class Environment(object):
         if not lock:
             flags |= _lib.MDB_NOLOCK
 
-        if isinstance(path, UnicodeType):
+        if isinstance(path, str):
             path = path.encode(sys.getfilesystemencoding())
 
         rc = _lib.mdb_env_open(self._env, path, flags, mode & ~O_0111)
@@ -1226,7 +1214,7 @@ class Environment(object):
             rc = _lib.mdb_reader_list(self._env, _msg_func, _ffi.NULL)
             if rc:
                 raise _error("mdb_reader_list", rc)
-            return UnicodeType().join(_callbacks.msg_func)
+            return "".join(_callbacks.msg_func)
         finally:
             del _callbacks.msg_func
 
@@ -1333,7 +1321,7 @@ class Environment(object):
                 duplicate value for a key to be stored without a header
                 indicating its size.  Implies `dupsort` is ``True``.
         """
-        if isinstance(key, UnicodeType):
+        if isinstance(key, str):
             raise TypeError('key must be bytes')
 
         if key is None and (reverse_key or dupsort or integerkey or integerdup
@@ -1403,7 +1391,7 @@ class Environment(object):
         return Transaction(self, db, parent, write, buffers)
 
 
-class _Database(object):
+class _Database:
     """
     Internal database handle.  This class is opaque, save a single method.
 
@@ -1465,7 +1453,7 @@ class _Database(object):
 open = Environment
 
 
-class Transaction(object):
+class Transaction:
     """
     A transaction object. All operations require a transaction handle,
     transactions may be read-only or read-write. Write transactions may not
@@ -1860,7 +1848,7 @@ class Transaction(object):
         return Cursor(db or self._db, self)
 
 
-class Cursor(object):
+class Cursor:
     """
     Structure for navigating a database.
 

--- a/lmdb/tool.py
+++ b/lmdb/tool.py
@@ -69,8 +69,6 @@ Basic tools for working with LMDB.
     watch: Show live environment statistics
 """
 
-from __future__ import absolute_import
-from __future__ import with_statement
 import array
 import collections
 import csv
@@ -368,7 +366,7 @@ def _find_diskstat(path):
                 return statpath
 
 
-class DiskStatter(object):
+class DiskStatter:
     FIELDS = (
         'reads',
         'reads_merged',

--- a/misc/run_in_vm.py
+++ b/misc/run_in_vm.py
@@ -1,26 +1,25 @@
 #
 # Copyright 2014 The py-lmdb authors, all rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted only as authorized by the OpenLDAP
 # Public License.
-# 
+#
 # A copy of this license is available in the file LICENSE in the
 # top-level directory of the distribution or, alternatively, at
 # <http://www.OpenLDAP.org/license.html>.
-# 
+#
 # OpenLDAP is a registered trademark of the OpenLDAP Foundation.
-# 
+#
 # Individual files and/or contributed packages may be copyright by
 # other parties and/or subject to additional restrictions.
-# 
+#
 # This work also contains materials derived from public sources.
-# 
+#
 # Additional information about OpenLDAP can be obtained at
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
 import atexit
 import json
 import os
@@ -37,7 +36,7 @@ def run(*args):
     try:
         subprocess.check_call(args)
     except:
-        print '!!! COMMAND WAS:', args
+        print('!!! COMMAND WAS:', args)
         raise
 
 
@@ -62,9 +61,9 @@ def qmp_command(fp, name, args):
     while True:
         o = qmp_read(fp)
         if 'return' not in o:
-            print 'skip', o
+            print('skip', o)
             continue
-        print 'cmd out', o
+        print('cmd out', o)
         return o['return']
 
 
@@ -88,7 +87,7 @@ def main():
                  '-net', 'user,hostfwd=tcp:127.0.0.1:9422-:22',
                  '-net', 'nic,model=virtio',
                  '-drive', 'file=%s,if=virtio' % (vm,)]
-    print ' '.join(qemu_args).replace('qmp', 'monitor')
+    print(' '.join(qemu_args).replace('qmp', 'monitor'))
     exit()
     proc = subprocess.Popen(qemu_args,
         stdin=wsock.fileno(), stdout=wsock.fileno()

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,6 @@
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
-from __future__ import with_statement
-
 import os
 import sys
 import shutil

--- a/tests/crash_test.py
+++ b/tests/crash_test.py
@@ -29,9 +29,6 @@
 # Various efforts to cause Python-level leaks.
 #
 
-from __future__ import absolute_import
-from __future__ import with_statement
-
 import gc
 import sys
 import itertools

--- a/tests/cursor_test.py
+++ b/tests/cursor_test.py
@@ -22,8 +22,6 @@
 
 # test delete(dupdata)
 
-from __future__ import absolute_import
-from __future__ import with_statement
 import os
 import sys
 import unittest

--- a/tests/cve_test.py
+++ b/tests/cve_test.py
@@ -27,7 +27,6 @@ the corruption instead of crashing.  They must be skipped when
 running against unpatched LMDB (pure or system), since the crashes are real.
 """
 
-from __future__ import absolute_import
 import os
 import struct
 import unittest

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -20,8 +20,6 @@
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
-from __future__ import with_statement
 import os
 import sys
 import unittest
@@ -31,14 +29,13 @@ import testlib
 from testlib import B
 from testlib import OCT
 from testlib import INT_TYPES
-from testlib import UnicodeType
 
 import lmdb
 
 # Whether we have the patch that allows env.copy* to take a txn
 have_txn_patch = lmdb.version(subpatch=True)[3]  # type: ignore[call-arg]
 
-NO_READERS = UnicodeType('(no active readers)\n')
+NO_READERS = str('(no active readers)\n')
 
 try:
     PAGE_SIZE = os.sysconf(os.sysconf_names['SC_PAGE_SIZE'])
@@ -413,7 +410,7 @@ class InfoMethodsTest(unittest.TestCase):
     def test_path(self):
         path, env = testlib.temp_env()
         assert path == env.path()
-        assert isinstance(env.path(), UnicodeType)
+        assert isinstance(env.path(), str)
 
         env.close()
         self.assertRaises(Exception,
@@ -491,12 +488,12 @@ class InfoMethodsTest(unittest.TestCase):
     def test_readers(self):
         _, env = testlib.temp_env(max_spare_txns=0)
         r = env.readers()
-        assert isinstance(r, UnicodeType)
+        assert isinstance(r, str)
         assert r == NO_READERS
 
         rtxn = env.begin()
         r2 = env.readers()
-        assert isinstance(env.readers(), UnicodeType)
+        assert isinstance(env.readers(), str)
         assert env.readers() != r
 
         env.close()
@@ -799,7 +796,7 @@ class OpenDbTest(unittest.TestCase):
         _, env = testlib.temp_env()
         assert env.open_db(B('myindex')) is not None
         self.assertRaises(TypeError,
-            lambda: env.open_db(UnicodeType('myindex')))  # type: ignore[arg-type]
+            lambda: env.open_db(str('myindex')))  # type: ignore[arg-type]
 
     def test_sub_notxn(self):
         _, env = testlib.temp_env()

--- a/tests/equiv_dump.py
+++ b/tests/equiv_dump.py
@@ -33,8 +33,6 @@ Usage:
     python tests/equiv_dump.py read <dir>      # Read existing DBs and dump to stdout
 """
 
-from __future__ import print_function
-
 import hashlib
 import os
 import sys

--- a/tests/getmulti_test.py
+++ b/tests/getmulti_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import with_statement
 import unittest
 
 import testlib, struct

--- a/tests/iteration_test.py
+++ b/tests/iteration_test.py
@@ -23,8 +23,6 @@
 
 # test delete(dupdata)
 
-from __future__ import absolute_import
-from __future__ import with_statement
 import unittest
 
 import testlib

--- a/tests/mdb_layout_test.py
+++ b/tests/mdb_layout_test.py
@@ -32,7 +32,6 @@ All data sizes are derived from env.stat()['psize'] at runtime so the
 tests work correctly regardless of OS page size (4K, 16K, etc.).
 """
 
-from __future__ import absolute_import
 import unittest
 
 import pytest

--- a/tests/package_test.py
+++ b/tests/package_test.py
@@ -20,7 +20,6 @@
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
 import unittest
 
 import lmdb

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -20,7 +20,6 @@
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
 import atexit
 import gc
 import os
@@ -92,9 +91,6 @@ def debug_collect():
         for x in range(10):
             # PyPy doesn't collect objects with __del__ on first attempt.
             gc.collect()
-
-UnicodeType = str
-BytesType = bytes
 
 INT_TYPES = (int,)
 

--- a/tests/tool_test.py
+++ b/tests/tool_test.py
@@ -20,8 +20,6 @@
 # <http://www.openldap.org/>.
 #
 
-from __future__ import absolute_import
-
 import os
 import shlex
 import sys

--- a/tests/txn_test.py
+++ b/tests/txn_test.py
@@ -29,7 +29,6 @@ import weakref
 import testlib
 from testlib import B
 from testlib import INT_TYPES
-from testlib import BytesType
 
 import lmdb
 
@@ -441,7 +440,7 @@ class GetTest(unittest.TestCase):
         _, env = testlib.temp_env()
         txn = env.begin()
         assert txn.get(B('a')) is None
-        assert txn.get(B('a'), default='default') is 'default'
+        assert txn.get(B('a'), default='default') == 'default'
 
     def test_empty_key(self):
         _, env = testlib.temp_env()
@@ -474,13 +473,13 @@ class GetTest(unittest.TestCase):
         _, env = testlib.temp_env()
         txn = env.begin(write=True)
         assert txn.put(B('a'), B('a'))
-        assert type(txn.get(B('a'))) is BytesType
+        assert type(txn.get(B('a'))) is bytes
 
     def test_buffers_yes(self):
         _, env = testlib.temp_env()
         txn = env.begin(write=True, buffers=True)
         assert txn.put(B('a'), B('a'))
-        assert type(txn.get(B('a'))) is not BytesType
+        assert type(txn.get(B('a'))) is not bytes
 
     def test_dupsort(self):
         _, env = testlib.temp_env()


### PR DESCRIPTION
While working on the type stubs I noticed some Python 2 compatibility code. After delving a bit deeper I also found a bunch Python 2 `print ''` statements and other Python 2 -only stuff. 
Anyway, I wasn't expecting this to be such a big PR :sweat_smile:. So let me know if I should split it up or something.