### PR TITLE
Fix parameter defaults for `Cursor.iter*` in `__init__.pyi`

### DIFF
--- a/lmdb/__init__.pyi
+++ b/lmdb/__init__.pyi
@@ -427,42 +427,50 @@ class Cursor(Generic[_VT_co]):
     @overload
     def iternext(
         self, keys: Literal[True] = True, values: Literal[True] = True
-    ) -> Iterator[tuple[_VT_co]]: ...
+    ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
     @overload
     def iternext(
         self, keys: Literal[True] = True, *, values: Literal[False]
     ) -> Iterator[_VT_co]: ...
     @overload
     def iternext(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[True], values: Literal[False]
+    ) -> Iterator[_VT_co]: ...
+    @overload
+    def iternext(
+        self, keys: Literal[False], values: Literal[True] = True
     ) -> Iterator[_VT_co]: ...
 
     # keep in sync with `iternext`
     @overload
     def iternext_dup(
-        self, keys: Literal[True] = True, values: Literal[True] = True
+        self, keys: Literal[True], values: Literal[True] = True
     ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
     @overload
     def iternext_dup(
-        self, keys: Literal[True] = True, *, values: Literal[False]
+        self, keys: Literal[True], values: Literal[False]
     ) -> Iterator[_VT_co]: ...
     @overload
     def iternext_dup(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[False] = False, values: Literal[True] = True
     ) -> Iterator[_VT_co]: ...
 
     # keep in sync with `iternext`
     @overload
     def iternext_nodup(
-        self, keys: Literal[True] = True, values: Literal[True] = True
+        self, keys: Literal[True] = True, *, values: Literal[True]
     ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
     @overload
     def iternext_nodup(
-        self, keys: Literal[True] = True, *, values: Literal[False]
+        self, keys: Literal[True], values: Literal[True]
+    ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
+    @overload
+    def iternext_nodup(
+        self, keys: Literal[True] = True, values: Literal[False] = False
     ) -> Iterator[_VT_co]: ...
     @overload
     def iternext_nodup(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[False], values: Literal[True]
     ) -> Iterator[_VT_co]: ...
 
     # keep in sync with `iternext`
@@ -476,35 +484,43 @@ class Cursor(Generic[_VT_co]):
     ) -> Iterator[_VT_co]: ...
     @overload
     def iterprev(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[True], values: Literal[False]
+    ) -> Iterator[_VT_co]: ...
+    @overload
+    def iterprev(
+        self, keys: Literal[False], values: Literal[True] = True
     ) -> Iterator[_VT_co]: ...
 
     # keep in sync with `iternext`
     @overload
     def iterprev_dup(
-        self, keys: Literal[True] = True, values: Literal[True] = True
+        self, keys: Literal[True], values: Literal[True] = True
     ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
     @overload
     def iterprev_dup(
-        self, keys: Literal[True] = True, *, values: Literal[False]
+        self, keys: Literal[True], values: Literal[False]
     ) -> Iterator[_VT_co]: ...
     @overload
     def iterprev_dup(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[False] = False, values: Literal[True] = True
     ) -> Iterator[_VT_co]: ...
 
     # keep in sync with `iternext`
     @overload
     def iterprev_nodup(
-        self, keys: Literal[True] = True, values: Literal[True] = True
+        self, keys: Literal[True] = True, *, values: Literal[True]
     ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
     @overload
     def iterprev_nodup(
-        self, keys: Literal[True] = True, *, values: Literal[False]
+        self, keys: Literal[True], values: Literal[True]
+    ) -> Iterator[tuple[_VT_co, _VT_co]]: ...
+    @overload
+    def iterprev_nodup(
+        self, keys: Literal[True] = True, values: Literal[False] = False
     ) -> Iterator[_VT_co]: ...
     @overload
     def iterprev_nodup(
-        self, keys: Literal[False], values: bool = True
+        self, keys: Literal[False], values: Literal[True]
     ) -> Iterator[_VT_co]: ...
 
     #


### PR DESCRIPTION
Ref: https://github.com/jnwatson/py-lmdb/pull/455#discussion_r3180508706

This also adds the missing overloads for the (valid) positional calls such as `_.iternext_nodup(True, True)`.