### PR TITLE
Runtime introspectable proxied `aio` methods

### DIFF
--- a/lmdb/aio.py
+++ b/lmdb/aio.py
@@ -188,6 +188,23 @@ class AsyncEnvironment:
 
     stat = _async_method(Environment.stat)
     info = _async_method(Environment.info)
+    close = _async_method(Environment.close)
+    copy = _async_method(Environment.copy)
+    copyfd = _async_method(Environment.copyfd)
+    sync = _async_method(Environment.sync)
+    readers = _async_method(Environment.readers)
+    reader_check = _async_method(Environment.reader_check)
+    set_mapsize = _async_method(Environment.set_mapsize)
+    open_db = _async_method(Environment.open_db)
+    dbs = _async_method(Environment.dbs)
+
+    # -- attribute fallback -----------------------------------------------
+
+    def __getattr__(self, name):
+        attr = getattr(self._env, name)
+        if callable(attr):
+            raise AttributeError(name)
+        return attr
 
 
 class AsyncTransaction:
@@ -262,6 +279,14 @@ class AsyncTransaction:
     pop = _async_method_locked(Transaction.pop)
     delete = _async_method_locked(Transaction.delete)
 
+    # -- attribute fallback -----------------------------------------------
+
+    def __getattr__(self, name):
+        attr = getattr(self._txn, name)
+        if callable(attr):
+            raise AttributeError(name)
+        return attr
+
 
 class AsyncCursor:
     """Async wrapper for :py:class:`lmdb.Cursor`.
@@ -331,3 +356,11 @@ class AsyncCursor:
     iterprev = _collect_locked(Cursor.iterprev)
     iterprev_dup = _collect_locked(Cursor.iterprev_dup)
     iterprev_nodup = _collect_locked(Cursor.iterprev_nodup)
+
+    # -- attribute fallback -----------------------------------------------
+
+    def __getattr__(self, name):
+        attr = getattr(self._cursor, name)
+        if callable(attr):
+            raise AttributeError(name)
+        return attr

--- a/lmdb/aio.py
+++ b/lmdb/aio.py
@@ -37,18 +37,7 @@ Usage::
 import asyncio
 import functools
 
-
-# Methods that are cheap, pure-Python accessors — no I/O, no GIL release.
-# Calling these through run_in_executor would just add overhead.
-_ENV_SYNC = frozenset({'path', 'max_key_size', 'max_readers', 'flags'})
-_TXN_SYNC = frozenset({'id'})
-_CURSOR_SYNC = frozenset({'key', 'value', 'item'})
-
-# Iterator methods return generators — must be consumed in the executor.
-_CURSOR_ITERS = frozenset({
-    'iternext', 'iternext_dup', 'iternext_nodup',
-    'iterprev', 'iterprev_dup', 'iterprev_nodup',
-})
+from lmdb import Cursor, Environment, Transaction
 
 
 def wrap(env, executor=None):
@@ -86,6 +75,61 @@ class _AsyncContextWrapper:
         return await self._result.__aexit__(exc_type, exc_val, exc_tb)
 
 
+# ---------------------------------------------------------------------------
+# Proxy method factories
+# ---------------------------------------------------------------------------
+
+def _sync_method(sync):
+    """Return a method that calls *sync* directly, without an executor."""
+    @functools.wraps(sync)
+    def method(self, *args, **kwargs):
+        return sync(getattr(self, self._WRAPS), *args, **kwargs)
+    return method
+
+
+def _async_method(sync):
+    """Return a coroutine method that calls *sync* in the executor."""
+    @functools.wraps(sync)
+    async def method(self, *args, **kwargs):
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            functools.partial(sync, getattr(self, self._WRAPS), *args, **kwargs),
+        )
+    return method
+
+
+def _async_method_locked(sync):
+    """Like :func:`_async_method`, but acquires ``self._lock`` first."""
+    @functools.wraps(sync)
+    async def method(self, *args, **kwargs):
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                self._executor,
+                functools.partial(sync, getattr(self, self._WRAPS), *args, **kwargs),
+            )
+    return method
+
+
+def _collect_locked(sync):
+    """Like :func:`_async_method_locked`, but *sync* returns an iterator
+    consumed in the executor and returned as a list."""
+    @functools.wraps(sync)
+    async def method(self, *args, **kwargs):
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            return await loop.run_in_executor(
+                self._executor,
+                lambda: list(sync(getattr(self, self._WRAPS), *args, **kwargs)),
+            )
+    return method
+
+
+# ---------------------------------------------------------------------------
+# Async wrappers
+# ---------------------------------------------------------------------------
+
 class AsyncEnvironment:
     """Async wrapper for :py:class:`lmdb.Environment`.
 
@@ -100,6 +144,8 @@ class AsyncEnvironment:
     """
 
     __slots__ = ('_env', '_executor')
+
+    _WRAPS = '_env'
 
     def __init__(self, env, executor=None):
         self._env = env
@@ -133,15 +179,15 @@ class AsyncEnvironment:
             return AsyncTransaction(txn, self._executor)
         return _AsyncContextWrapper(_begin())
 
-    # -- attribute proxy ---------------------------------------------------
+    # -- proxied methods --------------------------------------------------
 
-    def __getattr__(self, name):
-        attr = getattr(self._env, name)
-        if not callable(attr):
-            return attr
-        if name in _ENV_SYNC:
-            return attr
-        return _async_method(attr, self._executor)
+    path = _sync_method(Environment.path)
+    max_key_size = _sync_method(Environment.max_key_size)
+    max_readers = _sync_method(Environment.max_readers)
+    flags = _sync_method(Environment.flags)
+
+    stat = _async_method(Environment.stat)
+    info = _async_method(Environment.info)
 
 
 class AsyncTransaction:
@@ -159,6 +205,8 @@ class AsyncTransaction:
     """
 
     __slots__ = ('_txn', '_executor', '_lock')
+
+    _WRAPS = '_txn'
 
     def __init__(self, txn, executor=None):
         self._txn = txn
@@ -200,15 +248,19 @@ class AsyncTransaction:
             return AsyncCursor(cur, self._executor, self._lock)
         return _AsyncContextWrapper(_cursor())
 
-    # -- attribute proxy ---------------------------------------------------
+    # -- proxied methods --------------------------------------------------
 
-    def __getattr__(self, name):
-        attr = getattr(self._txn, name)
-        if not callable(attr):
-            return attr
-        if name in _TXN_SYNC:
-            return attr
-        return _async_method_locked(attr, self._executor, self._lock)
+    id = _sync_method(Transaction.id)
+
+    stat = _async_method_locked(Transaction.stat)
+    drop = _async_method_locked(Transaction.drop)
+    commit = _async_method_locked(Transaction.commit)
+    abort = _async_method_locked(Transaction.abort)
+    get = _async_method_locked(Transaction.get)
+    put = _async_method_locked(Transaction.put)
+    replace = _async_method_locked(Transaction.replace)
+    pop = _async_method_locked(Transaction.pop)
+    delete = _async_method_locked(Transaction.delete)
 
 
 class AsyncCursor:
@@ -228,6 +280,8 @@ class AsyncCursor:
 
     __slots__ = ('_cursor', '_executor', '_lock')
 
+    _WRAPS = '_cursor'
+
     def __init__(self, cursor, executor=None, lock=None):
         self._cursor = cursor
         self._executor = executor
@@ -241,81 +295,39 @@ class AsyncCursor:
     async def __aexit__(self, *_exc):
         self._cursor.close()
 
-    # -- iterators: consume in the executor and return a list -------------
+    # -- proxied methods --------------------------------------------------
 
-    async def iternext(self, **kw):
-        return await _collect_locked(
-            self._cursor.iternext, kw, self._executor, self._lock)
+    key = _sync_method(Cursor.key)
+    value = _sync_method(Cursor.value)
+    item = _sync_method(Cursor.item)
 
-    async def iternext_dup(self, **kw):
-        return await _collect_locked(
-            self._cursor.iternext_dup, kw, self._executor, self._lock)
+    close = _async_method_locked(Cursor.close)
+    first = _async_method_locked(Cursor.first)
+    first_dup = _async_method_locked(Cursor.first_dup)
+    last = _async_method_locked(Cursor.last)
+    last_dup = _async_method_locked(Cursor.last_dup)
+    prev = _async_method_locked(Cursor.prev)
+    prev_dup = _async_method_locked(Cursor.prev_dup)
+    prev_nodup = _async_method_locked(Cursor.prev_nodup)
+    next = _async_method_locked(Cursor.next)
+    next_dup = _async_method_locked(Cursor.next_dup)
+    next_nodup = _async_method_locked(Cursor.next_nodup)
+    set_key = _async_method_locked(Cursor.set_key)
+    set_key_dup = _async_method_locked(Cursor.set_key_dup)
+    set_range = _async_method_locked(Cursor.set_range)
+    set_range_dup = _async_method_locked(Cursor.set_range_dup)
+    delete = _async_method_locked(Cursor.delete)
+    count = _async_method_locked(Cursor.count)
+    put = _async_method_locked(Cursor.put)
+    putmulti = _async_method_locked(Cursor.putmulti)
+    replace = _async_method_locked(Cursor.replace)
+    pop = _async_method_locked(Cursor.pop)
+    get = _async_method_locked(Cursor.get)
+    getmulti = _async_method_locked(Cursor.getmulti)
 
-    async def iternext_nodup(self, **kw):
-        return await _collect_locked(
-            self._cursor.iternext_nodup, kw, self._executor, self._lock)
-
-    async def iterprev(self, **kw):
-        return await _collect_locked(
-            self._cursor.iterprev, kw, self._executor, self._lock)
-
-    async def iterprev_dup(self, **kw):
-        return await _collect_locked(
-            self._cursor.iterprev_dup, kw, self._executor, self._lock)
-
-    async def iterprev_nodup(self, **kw):
-        return await _collect_locked(
-            self._cursor.iterprev_nodup, kw, self._executor, self._lock)
-
-    # -- attribute proxy ---------------------------------------------------
-
-    def __getattr__(self, name):
-        attr = getattr(self._cursor, name)
-        if not callable(attr):
-            return attr
-        if name in _CURSOR_SYNC:
-            return attr
-        if name in _CURSOR_ITERS:
-            return functools.partial(
-                _collect_locked, attr, {}, self._executor, self._lock)
-        return _async_method_locked(attr, self._executor, self._lock)
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _async_method(method, executor):
-    """Return a coroutine function that calls *method* in *executor*."""
-    @functools.wraps(method)
-    async def wrapper(*args, **kwargs):
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            executor,
-            functools.partial(method, *args, **kwargs),
-        )
-    return wrapper
-
-
-def _async_method_locked(method, executor, lock):
-    """Like :func:`_async_method`, but acquires *lock* first."""
-    @functools.wraps(method)
-    async def wrapper(*args, **kwargs):
-        async with lock:
-            loop = asyncio.get_running_loop()
-            return await loop.run_in_executor(
-                executor,
-                functools.partial(method, *args, **kwargs),
-            )
-    return wrapper
-
-
-async def _collect_locked(iter_method, kwargs, executor, lock):
-    """Call an iterator method in the executor and return a list."""
-    loop = asyncio.get_running_loop()
-
-    def _consume():
-        return list(iter_method(**kwargs))
-
-    async with lock:
-        return await loop.run_in_executor(executor, _consume)
+    iternext = _collect_locked(Cursor.iternext)
+    iternext_dup = _collect_locked(Cursor.iternext_dup)
+    iternext_nodup = _collect_locked(Cursor.iternext_nodup)
+    iterprev = _collect_locked(Cursor.iterprev)
+    iterprev_dup = _collect_locked(Cursor.iterprev_dup)
+    iterprev_nodup = _collect_locked(Cursor.iterprev_nodup)

--- a/tests/aio_test.py
+++ b/tests/aio_test.py
@@ -337,5 +337,32 @@ class AsyncConcurrencyTest(testlib.LmdbTest):
         run(go())
 
 
+class IntrospectionTest(unittest.TestCase):
+    """Proxied methods must be real class attributes (dir/inspect/stubtest)."""
+
+    def test_methods_are_real_attributes(self):
+        for cls, names in (
+            (lmdb.aio.AsyncEnvironment, ('path', 'stat', 'info')),
+            (lmdb.aio.AsyncTransaction, ('id', 'get', 'put', 'commit')),
+            (lmdb.aio.AsyncCursor, ('key', 'get', 'iternext', 'getmulti')),
+        ):
+            for name in names:
+                self.assertIn(name, dir(cls))
+                self.assertIn(name, vars(cls))
+
+    def test_async_method_metadata(self):
+        import inspect
+        get = vars(lmdb.aio.AsyncTransaction)['get']
+        self.assertTrue(inspect.iscoroutinefunction(get))
+        self.assertIs(get.__wrapped__, lmdb.Transaction.get)
+        self.assertEqual(get.__doc__, lmdb.Transaction.get.__doc__)
+
+    def test_passthrough_is_not_a_coroutine(self):
+        import inspect
+        path = vars(lmdb.aio.AsyncEnvironment)['path']
+        self.assertFalse(inspect.iscoroutinefunction(path))
+        self.assertIs(path.__wrapped__, lmdb.Environment.path)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/aio_test.py
+++ b/tests/aio_test.py
@@ -8,6 +8,7 @@
 """Tests for lmdb.aio async wrappers."""
 
 import asyncio
+import inspect
 import unittest
 
 import lmdb
@@ -350,18 +351,52 @@ class IntrospectionTest(unittest.TestCase):
                 self.assertIn(name, dir(cls))
                 self.assertIn(name, vars(cls))
 
+    def test_all_public_methods_proxied(self):
+        for wrapped, wrapper in (
+            (lmdb.Environment, lmdb.aio.AsyncEnvironment),
+            (lmdb.Transaction, lmdb.aio.AsyncTransaction),
+            (lmdb.Cursor, lmdb.aio.AsyncCursor),
+        ):
+            public = {
+                n for n in dir(wrapped)
+                if not n.startswith('_') and callable(getattr(wrapped, n))
+            }
+            missing = public - set(vars(wrapper))
+            self.assertFalse(missing, f"missing: {sorted(missing)}")
+
     def test_async_method_metadata(self):
-        import inspect
         get = vars(lmdb.aio.AsyncTransaction)['get']
         self.assertTrue(inspect.iscoroutinefunction(get))
         self.assertIs(get.__wrapped__, lmdb.Transaction.get)
         self.assertEqual(get.__doc__, lmdb.Transaction.get.__doc__)
 
     def test_passthrough_is_not_a_coroutine(self):
-        import inspect
         path = vars(lmdb.aio.AsyncEnvironment)['path']
         self.assertFalse(inspect.iscoroutinefunction(path))
         self.assertIs(path.__wrapped__, lmdb.Environment.path)
+
+
+class GetattrFallbackTest(testlib.LmdbTest):
+    """Non-callable attributes proxy through `__getattr__` (CFFI-only)."""
+
+    def tearDown(self):
+        testlib.cleanup()
+
+    def test_fallback(self):
+        _, env = testlib.temp_env()
+        if not hasattr(env, 'readonly'):
+            self.skipTest('CFFI-only')
+
+        aenv = lmdb.aio.wrap(env)
+        self.assertEqual(getattr(aenv, 'readonly'), env.readonly)
+
+        async def go():
+            async with aenv.begin() as txn:
+                self.assertIs(txn.env, txn._txn.env)
+                async with txn.cursor() as cur:
+                    self.assertIs(cur.db, cur._cursor.db)
+                    self.assertIs(cur.txn, cur._cursor.txn)
+        run(go())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
While working on #455 (`aio.pyi` stubs) I was bascially sailing in the blind because I couldn't use stubtest. That's because stubtest uses runtime introspection (`inspect.signature` and `dir` and such) to determine the methods and signatures of a given class. But because `__getattr__` was used to proxy and wrap the sync methods, this wasn't working. 
I then realized that this issue wasn't limited to stubtest, and that it could also lead to issues in e.g. IPython, or when doing manually `dir()` or `help()` on those proxied methods.

Anyway, this fixes those issues by directly wrapping each of the sync methods from `Transaction`, `Environment`, and `Cursor` using `functools`. It's not as DRY as it was, but I think it's a pretty clean solution and that the benefits are worth it.