### PR TITLE
Avoid impl-defined narrowing of adversarial mv_size in cpython.c

### DIFF
--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -591,10 +591,17 @@ dict_from_fields(void *o, const struct dict_field *fields)
 static PyObject *
 obj_from_val(MDB_val *val, int as_buffer)
 {
-    if(as_buffer) {
-        return PyMemoryView_FromMemory(val->mv_data, val->mv_size, PyBUF_READ);
+    if(val->mv_size > (size_t) PY_SSIZE_T_MAX) {
+        PyErr_SetString(PyExc_OverflowError,
+            "value too large to convert (corrupt database?)");
+        return NULL;
     }
-    return PyBytes_FromStringAndSize(val->mv_data, val->mv_size);
+    if(as_buffer) {
+        return PyMemoryView_FromMemory(val->mv_data,
+                                       (Py_ssize_t) val->mv_size, PyBUF_READ);
+    }
+    return PyBytes_FromStringAndSize(val->mv_data,
+                                     (Py_ssize_t) val->mv_size);
 }
 
 /* Track Py_buffer views acquired during argument parsing so they can be
@@ -2582,7 +2589,8 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
         int values;
     } arg = {Py_None, 0, 0, 0, 1};
 
-    int i, as_buffer;
+    int as_buffer;
+    size_t i;
     PyObject *iter, *item, *tup, *key, *val;
     PyObject *pylist = NULL;
     MDB_cursor_op get_op, next_op;
@@ -2700,7 +2708,7 @@ cursor_get_multi(CursorObject *self, PyObject *args, PyObject *kwds)
                     }
                 } else {
                     /* dupfixed, MDB_GET_MULTIPLE returns batch, iterate values */
-                    int items = (int) self->val.mv_size/val_size;
+                    size_t items = self->val.mv_size / val_size;
                     if (first) {
                         key_size = (size_t) self->key.mv_size;
                         /* key_size is from a (possibly adversarial) on-disk


### PR DESCRIPTION
## Summary

Follow-up to #462 — two remaining spots where a `size_t` from an on-disk record is narrowed to a signed type via an implementation-defined conversion. Neither is exploitable in the same way as the issues in #462 (no OOB write, no malloc-size wrap), but both rely on conversion behavior the C standard doesn't pin down and at least one silently returns wrong data.

## Sites

### 1. `obj_from_val` (size_t → Py_ssize_t)

```c
return PyBytes_FromStringAndSize(val->mv_data, val->mv_size);
```

`PyBytes_FromStringAndSize` / `PyMemoryView_FromMemory` take `Py_ssize_t`. On 64-bit platforms `mv_size > PY_SSIZE_T_MAX` (`2^63`) converts in a way the standard does not pin down. In practice CPython then rejects the resulting negative size, but the safe contract is "don't pass it in the first place."

Fix: explicit upper-bound check + explicit `(Py_ssize_t)` cast.

### 2. `cursor_get_multi` items count

```c
int items = (int) self->val.mv_size / val_size;
```

Cast precedence makes this `((int) mv_size) / val_size`. For `mv_size > INT_MAX` the count is computed from a truncated / sign-flipped value and is silently wrong. The dupfixed batch is still read within its own bounds because `items * val_size <= mv_size` holds modulo whatever the truncated `int` value happens to be, so this is a correctness bug rather than a memory-safety bug — but on an adversarial DB you'd get wrong results.

Fix: switch `items` and the loop counter `i` to `size_t`; drop the cast. (Division-by-zero is already prevented by the enclosing `if (!arg.dupfixed_bytes)` branch — noted in the comment.)

## Test plan

- [x] CPython extension builds clean (MSVC, Python 3.13, Windows x64) — no new warnings
- [x] Full `pytest tests/` passes (352 passed, 4 skipped) — no regression
- [x] CI on Linux/macOS

No new tests for the same reason as #462 — these branches can't be reached by legitimate usage. Happy to add an adversarial-mmap test if you want one for the whole hardening series.
