### PR TITLE
aio: pin write transactions to a private single-thread executor

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,18 @@
 unreleased
 ##########
 
+Bug fixes
+---------
+
+- ``lmdb.aio``: an async write transaction is now pinned to a private
+    single-thread executor, so its ``begin``, operations, and
+    ``commit``/``abort`` all run on one OS thread. Previously they were
+    dispatched across the shared, multi-threaded default executor, which could
+    release LMDB's thread-bound robust write mutex on the wrong thread (the
+    failure mode of #465). ``AsyncCursor``/``AsyncEnvironment`` close on
+    context exit now also acquire the lock and run on the executor, so closing
+    can no longer race an in-flight operation on the same transaction.
+
 Improvements
 ------------
 

--- a/lmdb/aio.py
+++ b/lmdb/aio.py
@@ -36,6 +36,7 @@ Usage::
 
 import asyncio
 import functools
+from concurrent.futures import ThreadPoolExecutor
 
 from . import Cursor, Environment, Transaction
 
@@ -158,7 +159,8 @@ class AsyncEnvironment:
         return self
 
     async def __aexit__(self, *_exc):
-        self._env.close()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, self._env.close)
 
     # -- methods that return wrapped objects -------------------------------
 
@@ -170,14 +172,34 @@ class AsyncEnvironment:
 
             async with aenv.begin(write=True) as txn:
                 await txn.put(b'key', b'value')
+
+        A **write** transaction is given its own private single-thread
+        executor, so ``begin``, every operation, and ``commit``/``abort`` all
+        run on one OS thread.  LMDB ties a write transaction (and, on Linux,
+        its robust process-shared write mutex) to the thread that began it, so
+        dispatching its operations across a shared multi-threaded executor
+        could release the mutex on the wrong thread (see issue #465).  Read
+        transactions are safe to migrate between threads under ``MDB_NOTLS``
+        and use the environment's executor.
         """
+        # begin(db=None, parent=None, write=False, buffers=False)
+        write = bool(kwargs.get('write', args[2] if len(args) > 2 else False))
+
         async def _begin():
+            private = ThreadPoolExecutor(max_workers=1) if write else None
+            executor = private if private is not None else self._executor
             loop = asyncio.get_running_loop()
-            txn = await loop.run_in_executor(
-                self._executor,
-                functools.partial(self._env.begin, *args, **kwargs),
-            )
-            return AsyncTransaction(txn, self._executor)
+            try:
+                txn = await loop.run_in_executor(
+                    executor,
+                    functools.partial(self._env.begin, *args, **kwargs),
+                )
+            except BaseException:
+                if private is not None:
+                    private.shutdown(wait=False)
+                raise
+            return AsyncTransaction(
+                txn, executor, owns_executor=private is not None)
         return _AsyncContextWrapper(_begin())
 
     # -- proxied methods --------------------------------------------------
@@ -222,14 +244,26 @@ class AsyncTransaction:
     and aborted on exception.
     """
 
-    __slots__ = ('_txn', '_executor', '_lock')
+    __slots__ = ('_txn', '_executor', '_lock', '_owns_executor', '_done')
 
     _WRAPS = '_txn'
 
-    def __init__(self, txn, executor=None):
+    def __init__(self, txn, executor=None, owns_executor=False):
         self._txn = txn
         self._executor = executor
+        # True for write transactions, whose *executor* is a private
+        # single-thread pool created by :py:meth:`AsyncEnvironment.begin` and
+        # torn down when the transaction finishes.
+        self._owns_executor = owns_executor
+        self._done = False
         self._lock = asyncio.Lock()
+
+    def _shutdown_executor(self):
+        if self._owns_executor:
+            self._owns_executor = False
+            executor = self._executor
+            assert executor is not None  # an owned executor is a real pool
+            executor.shutdown(wait=False)
 
     # -- context manager --------------------------------------------------
 
@@ -238,11 +272,20 @@ class AsyncTransaction:
 
     async def __aexit__(self, exc_type, _exc_val, _exc_tb):
         async with self._lock:
-            if exc_type:
-                self._txn.abort()
-            else:
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(self._executor, self._txn.commit)
+            # An explicit commit()/abort() may already have finished the txn.
+            if self._done:
+                return
+            self._done = True
+            loop = asyncio.get_running_loop()
+            try:
+                # abort, like commit, must run on the executor so that a
+                # write txn releases its thread-bound mutex on its own thread.
+                if exc_type:
+                    await loop.run_in_executor(self._executor, self._txn.abort)
+                else:
+                    await loop.run_in_executor(self._executor, self._txn.commit)
+            finally:
+                self._shutdown_executor()
 
     # -- methods that return wrapped objects -------------------------------
 
@@ -272,13 +315,31 @@ class AsyncTransaction:
 
     stat = _async_method_locked(Transaction.stat)
     drop = _async_method_locked(Transaction.drop)
-    commit = _async_method_locked(Transaction.commit)
-    abort = _async_method_locked(Transaction.abort)
     get = _async_method_locked(Transaction.get)
     put = _async_method_locked(Transaction.put)
     replace = _async_method_locked(Transaction.replace)
     pop = _async_method_locked(Transaction.pop)
     delete = _async_method_locked(Transaction.delete)
+
+    async def commit(self):
+        """Commit the transaction and release its executor if privately owned."""
+        async with self._lock:
+            self._done = True
+            loop = asyncio.get_running_loop()
+            try:
+                await loop.run_in_executor(self._executor, self._txn.commit)
+            finally:
+                self._shutdown_executor()
+
+    async def abort(self):
+        """Abort the transaction and release its executor if privately owned."""
+        async with self._lock:
+            self._done = True
+            loop = asyncio.get_running_loop()
+            try:
+                await loop.run_in_executor(self._executor, self._txn.abort)
+            finally:
+                self._shutdown_executor()
 
     # -- attribute fallback -----------------------------------------------
 
@@ -319,7 +380,12 @@ class AsyncCursor:
         return self
 
     async def __aexit__(self, *_exc):
-        self._cursor.close()
+        # Serialize with sibling operations on the shared transaction and run
+        # on the executor, so closing never races an in-flight op in a worker
+        # thread (which would touch the same MDB_txn concurrently).
+        async with self._lock:
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(self._executor, self._cursor.close)
 
     # -- proxied methods --------------------------------------------------
 

--- a/lmdb/aio.pyi
+++ b/lmdb/aio.pyi
@@ -126,14 +126,19 @@ class AsyncEnvironment:
     async def dbs(self, txn: Transaction[_VT]) -> list[_VT]: ...
 
 class AsyncTransaction(Generic[_VT_co]):
-    __slots__ = "_txn", "_executor", "_lock"
+    __slots__ = "_txn", "_executor", "_lock", "_owns_executor", "_done"
 
     _txn: Transaction[_VT_co]
     _executor: Final[Executor | None]
     _lock: Final[asyncio.Lock]
+    _owns_executor: bool
+    _done: bool
 
     def __init__(
-        self, txn: Transaction[_VT_co], executor: Executor | None = None
+        self,
+        txn: Transaction[_VT_co],
+        executor: Executor | None = None,
+        owns_executor: bool = False,
     ) -> None: ...
     async def __aenter__(self) -> Self: ...
     async def __aexit__(

--- a/tests/aio_test.py
+++ b/tests/aio_test.py
@@ -338,6 +338,123 @@ class AsyncConcurrencyTest(testlib.LmdbTest):
         run(go())
 
 
+class WriteExecutorTest(testlib.LmdbTest):
+    """Write txns must run entirely on one OS thread (issue #465).
+
+    LMDB ties a write transaction — and, on Linux, its robust process-shared
+    write mutex — to the thread that began it.  The wrapper therefore gives
+    each write txn a private single-thread executor rather than dispatching
+    its begin/op/commit across a shared, multi-threaded executor.
+    """
+
+    def tearDown(self):
+        testlib.cleanup()
+
+    def test_write_txn_gets_private_single_thread_executor(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        async def go():
+            _, env = testlib.temp_env()
+            pool = ThreadPoolExecutor(4)  # deliberately multi-threaded
+            aenv = lmdb.aio.wrap(env, executor=pool)
+            async with aenv.begin(write=True) as txn:
+                self.assertTrue(txn._owns_executor)
+                self.assertIsNot(txn._executor, pool)
+                self.assertIsInstance(txn._executor, ThreadPoolExecutor)
+                self.assertEqual(txn._executor._max_workers, 1)
+                # A cursor inherits the txn's private executor, so its
+                # operations stay on the same thread as the write txn.
+                async with txn.cursor() as cur:
+                    self.assertIs(cur._executor, txn._executor)
+            pool.shutdown(wait=False)
+
+        run(go())
+
+    def test_read_txn_uses_env_executor(self):
+        from concurrent.futures import ThreadPoolExecutor
+
+        async def go():
+            _, env = testlib.temp_env()
+            pool = ThreadPoolExecutor(4)
+            aenv = lmdb.aio.wrap(env, executor=pool)
+            async with aenv.begin() as txn:  # read-only
+                self.assertFalse(txn._owns_executor)
+                self.assertIs(txn._executor, pool)
+            pool.shutdown(wait=False)
+
+        run(go())
+
+    def test_private_executor_released_on_commit(self):
+        async def go():
+            _, env = testlib.temp_env()
+            aenv = lmdb.aio.wrap(env)
+            async with aenv.begin(write=True) as txn:
+                await txn.put(b'k', b'v')
+                priv = txn._executor
+            # Left the block cleanly -> committed -> private pool shut down.
+            with self.assertRaises(RuntimeError):
+                priv.submit(lambda: None)
+            self.assertFalse(txn._owns_executor)
+
+        run(go())
+
+    def test_private_executor_released_on_abort(self):
+        async def go():
+            _, env = testlib.temp_env()
+            aenv = lmdb.aio.wrap(env)
+            priv = None
+            try:
+                async with aenv.begin(write=True) as txn:
+                    priv = txn._executor
+                    await txn.put(b'k', b'v')
+                    raise ValueError('boom')
+            except ValueError:
+                pass
+            # Exception -> aborted -> private pool shut down; data not written.
+            with self.assertRaises(RuntimeError):
+                priv.submit(lambda: None)
+            async with aenv.begin() as txn:
+                self.assertIsNone(await txn.get(b'k'))
+
+        run(go())
+
+    def test_explicit_commit_then_context_exit_is_noop(self):
+        """commit()/abort() finalize the txn; __aexit__ must not commit again."""
+        async def go():
+            _, env = testlib.temp_env()
+            aenv = lmdb.aio.wrap(env)
+            async with aenv.begin(write=True) as txn:
+                await txn.put(b'k', b'v')
+                await txn.commit()
+                self.assertTrue(txn._done)
+                # __aexit__ runs next; a second commit on the underlying txn
+                # would raise, so a clean exit proves it was a no-op.
+            async with aenv.begin() as txn:
+                self.assertEqual(await txn.get(b'k'), b'v')
+
+        run(go())
+
+    def test_writes_with_multithread_env_executor(self):
+        """Repeated write txns through a multi-threaded env executor must not
+        release the write mutex on the wrong thread."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        async def go():
+            _, env = testlib.temp_env()
+            pool = ThreadPoolExecutor(8)
+            aenv = lmdb.aio.wrap(env, executor=pool)
+            for i in range(50):
+                async with aenv.begin(write=True) as txn:
+                    await txn.put(str(i).encode(), str(i).encode())
+            async with aenv.begin() as txn:
+                for i in range(50):
+                    self.assertEqual(
+                        await txn.get(str(i).encode()), str(i).encode())
+            pool.shutdown(wait=False)
+
+        run(go())
+
+
 class IntrospectionTest(unittest.TestCase):
     """Proxied methods must be real class attributes (dir/inspect/stubtest)."""
 

--- a/tests/aio_test.py
+++ b/tests/aio_test.py
@@ -359,9 +359,10 @@ class WriteExecutorTest(testlib.LmdbTest):
             aenv = lmdb.aio.wrap(env, executor=pool)
             async with aenv.begin(write=True) as txn:
                 self.assertTrue(txn._owns_executor)
-                self.assertIsNot(txn._executor, pool)
-                self.assertIsInstance(txn._executor, ThreadPoolExecutor)
-                self.assertEqual(txn._executor._max_workers, 1)
+                private = txn._executor
+                self.assertIsNot(private, pool)
+                assert isinstance(private, ThreadPoolExecutor)
+                self.assertEqual(private._max_workers, 1)
                 # A cursor inherits the txn's private executor, so its
                 # operations stay on the same thread as the write txn.
                 async with txn.cursor() as cur:
@@ -391,6 +392,7 @@ class WriteExecutorTest(testlib.LmdbTest):
             async with aenv.begin(write=True) as txn:
                 await txn.put(b'k', b'v')
                 priv = txn._executor
+                assert priv is not None  # write txns own a private pool
             # Left the block cleanly -> committed -> private pool shut down.
             with self.assertRaises(RuntimeError):
                 priv.submit(lambda: None)
@@ -411,6 +413,7 @@ class WriteExecutorTest(testlib.LmdbTest):
             except ValueError:
                 pass
             # Exception -> aborted -> private pool shut down; data not written.
+            assert priv is not None  # write txns own a private pool
             with self.assertRaises(RuntimeError):
                 priv.submit(lambda: None)
             async with aenv.begin() as txn:


### PR DESCRIPTION
## Problem

A concurrency review of `lmdb.aio` found two real correctness issues (pre-existing since #434):

**1. Write transactions were not pinned to one OS thread.** LMDB ties a write transaction — and, on Linux, its robust process-shared write mutex — to the thread that began it (`MDB_NOTLS` doesn't change this for writes). The wrapper dispatched every operation through the loop's shared, multi-threaded default executor, serialized only by an `asyncio.Lock`. The lock prevents overlap but gives no thread affinity: `begin`, `put`, and `commit` for a single write txn could each land on a different pool thread, releasing the write mutex on the wrong thread — the exact failure mode #465 fixed at the C level (dangling robust-list entry → later `begin()` crashes in `pthread_mutex_lock` on aarch64). Tests passed only because an idle pool tends to reuse the same worker; any unrelated executor traffic scatters the ops.

**2. Close-on-exit bypassed the lock.** `AsyncCursor.__aexit__` and `AsyncEnvironment.__aexit__` called `close()` synchronously on the event-loop thread, without the lock — contradicting the documented "`asyncio.gather` is safe on the same transaction" guarantee. An `async with cur:` exit could race a sibling coroutine's in-flight op touching the same `MDB_txn` in a worker thread.

## Fix

- `AsyncEnvironment.begin(write=True)` now creates a private `ThreadPoolExecutor(max_workers=1)` for that transaction; `begin`, every operation (including its cursors' ops), and `commit`/`abort` all run on that one thread. The pool is shut down when the txn finishes — context exit or explicit `commit()`/`abort()` — with guards against leak/double-shutdown, including when `begin` itself raises. Read txns may legally migrate threads under `MDB_NOTLS` and keep using the environment's executor.
- `AsyncCursor.__aexit__` / `AsyncEnvironment.__aexit__` now acquire the lock and dispatch `close()` through the executor. The abort-on-exception path in `AsyncTransaction.__aexit__` also moved onto the executor (abort releases the write mutex too).
- Explicit `commit()`/`abort()` set a `_done` flag so a following `__aexit__` is a no-op instead of a double commit.
- `lmdb/aio.pyi` updated to match (`__slots__`, `__init__(owns_executor=...)`); ChangeLog entry added.

## Testing

- 6 new regression tests (`WriteExecutorTest`): private single-thread executor for writes (even with a deliberately multi-threaded env executor), shared executor for reads, pool released on commit *and* on abort, explicit-commit-then-context-exit no-op, and a 50-write-txn workload through an 8-thread env executor.
- Full suite green on both backends: 366 passed / 1 skipped (cpython), 365 passed / 2 skipped (cffi).
- Type gates green: mypy clean, pyright 0 errors / 0 warnings, stubtest clean.

Known limitation (pre-existing, unchanged): nested write transactions (`begin(write=True, parent=...)`) aren't cleanly supported by the wrapper; a child would get its own executor rather than the parent's thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jhdaa7AFFLQieGnMNsftp8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhdaa7AFFLQieGnMNsftp8)_