### PR TITLE
Fix EIO/truncation writing multi-GB overflow values

### DIFF
--- a/lib/py-lmdb/fix-large-write.patch
+++ b/lib/py-lmdb/fix-large-write.patch
@@ -1,0 +1,50 @@
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -3489,16 +3489,32 @@
+ 				}
+ #endif
+ 				if (wres != wsize) {
++					ssize_t rem;
++					int k;
+ 					if (wres < 0) {
+ 						rc = ErrCode();
+ 						if (rc == EINTR)
+ 							goto retry_write;
+ 						DPRINTF(("Write error: %s", strerror(rc)));
+-					} else {
+-						rc = EIO; /* TODO: Use which error code? */
+-						DPUTS("short write, filesystem full?");
++						return rc;
+ 					}
+-					return rc;
++					rem = wres;
++					k = 0;
++					while (k < n && rem >= (ssize_t)iov[k].iov_len) {
++						rem -= (ssize_t)iov[k].iov_len;
++						k++;
++					}
++					if (k) {
++						memmove(iov, iov + k, (n - k) * sizeof(iov[0]));
++						n -= k;
++					}
++					if (n) {
++						iov[0].iov_base = (char *)iov[0].iov_base + rem;
++						iov[0].iov_len -= (size_t)rem;
++					}
++					wpos += wres;
++					wsize -= wres;
++					goto retry_write;
+ 				}
+ 				n = 0;
+ 			}
+@@ -9400,7 +9416,8 @@
+ again:
+ 		rc = MDB_SUCCESS;
+ 		while (wsize > 0 && !my->mc_error) {
+-			DO_WRITE(rc, my->mc_fd, ptr, wsize, len);
++			size_t w2 = wsize > MAX_WRITE ? MAX_WRITE : wsize;
++			DO_WRITE(rc, my->mc_fd, ptr, w2, len);
+ 			if (!rc) {
+ 				rc = ErrCode();
+ #if defined(SIGPIPE) && !defined(_WIN32)

--- a/misc/large-write-repro.c
+++ b/misc/large-write-repro.c
@@ -1,0 +1,98 @@
+/*
+ * Reproducer for: mdb_txn_commit() fails with EIO when a single value is
+ * larger than the platform per-call write limit (~2 GiB on Linux).
+ *
+ * A value that does not fit in a normal page is stored in one contiguous
+ * overflow page and flushed by mdb_page_flush() in a single pwrite()/writev()
+ * of mp_pages * psize bytes.  Linux write()/pwrite() transfers at most
+ * 0x7ffff000 bytes and returns a *short count*; mdb_page_flush() compares that
+ * count with the requested size and treats the mismatch as fatal
+ * ("short write, filesystem full?"), returning EIO.  So committing any value
+ * larger than ~2 GiB fails, even though the value is well within MAXDATASIZE
+ * (4 GiB - 1) and there is plenty of free space.
+ *
+ * (On Windows the analogous single WriteFile() in the compacting-copy writer
+ * mdb_env_copythr() truncates its size_t length to a 32-bit DWORD.)
+ *
+ *   Unpatched:  "BUG REPRODUCED: mdb_txn_commit failed: Input/output error"
+ *   Fixed:      "OK: committed and read back 2415919104-byte value intact"
+ *
+ * Build:  gcc -O2 -o repro large-write-repro.c mdb.c midl.c -lpthread
+ * Run:    ./repro [scratch-dir]      (64-bit only; needs ~2.5 GiB RAM + disk)
+ *
+ * Exit status: 0 = fixed/OK, 1 = bug reproduced, 2 = setup error.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "lmdb.h"
+
+#define CHK(expr) do { int rc_ = (expr); if (rc_) { \
+    fprintf(stderr, "%s:%d: %s: %s\n", __FILE__, __LINE__, #expr, \
+            mdb_strerror(rc_)); return 2; } } while (0)
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : "./lw-repro-db";
+    /* 2.25 GiB: one overflow page whose single write exceeds the ~2 GiB
+     * per-call limit (0x7ffff000). */
+    const size_t VALSIZE = (size_t)0x90000000UL;
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_val key, val, got;
+    char *buf;
+    int rc;
+
+    if (sizeof(size_t) < 8) {
+        fprintf(stderr, "This reproducer requires a 64-bit build.\n");
+        return 2;
+    }
+
+    mkdir(dir, 0755);
+
+    buf = (char *)malloc(VALSIZE);
+    if (!buf) { fprintf(stderr, "malloc(%zu) failed\n", VALSIZE); return 2; }
+    memset(buf, 'x', VALSIZE);
+    memcpy(buf, "HEAD", 4);
+    memcpy(buf + VALSIZE - 4, "TAIL", 4);
+
+    CHK(mdb_env_create(&env));
+    CHK(mdb_env_set_mapsize(env, VALSIZE + (512UL << 20)));
+    CHK(mdb_env_open(env, dir, 0, 0664));
+
+    CHK(mdb_txn_begin(env, NULL, 0, &txn));
+    CHK(mdb_dbi_open(txn, NULL, 0, &dbi));
+    key.mv_data = (void *)"big"; key.mv_size = 3;
+    val.mv_data = buf;          val.mv_size = VALSIZE;
+    CHK(mdb_put(txn, dbi, &key, &val, 0));
+
+    rc = mdb_txn_commit(txn);
+    if (rc) {
+        fprintf(stderr, "BUG REPRODUCED: mdb_txn_commit failed: %s (rc=%d)\n",
+                mdb_strerror(rc), rc);
+        mdb_env_close(env);
+        free(buf);
+        return 1;
+    }
+
+    /* Verify the value round-trips without truncation. */
+    CHK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+    CHK(mdb_get(txn, dbi, &key, &got));
+    if (got.mv_size != VALSIZE ||
+        memcmp(got.mv_data, "HEAD", 4) != 0 ||
+        memcmp((char *)got.mv_data + VALSIZE - 4, "TAIL", 4) != 0) {
+        fprintf(stderr, "BUG: value corrupt/truncated: got %zu of %zu bytes\n",
+                got.mv_size, VALSIZE);
+        mdb_txn_abort(txn); mdb_env_close(env); free(buf);
+        return 1;
+    }
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+    free(buf);
+
+    printf("OK: committed and read back %zu-byte value intact\n", VALSIZE);
+    return 0;
+}

--- a/misc/large-write.md
+++ b/misc/large-write.md
@@ -1,0 +1,47 @@
+# Large single-write handling for multi-GB overflow values
+
+Fixed by `lib/py-lmdb/fix-large-write.patch`.
+
+## What
+
+A single LMDB value is stored in one contiguous overflow page spanning
+`mp_pages` pages, and is written to disk in a single call of `mp_pages * psize`
+bytes.  For a value larger than ~2 GiB that single call exceeds platform
+per-call write limits:
+
+* **POSIX** — Linux `write()`/`pwrite()` transfers at most `0x7ffff000`
+  (~2 GiB) and returns a short count.  In `mdb_page_flush` the short count was
+  compared with the requested size and treated as fatal
+  (`rc = EIO; "short write, filesystem full?"`), so committing a >2 GiB value
+  failed with `EIO`.
+* **Windows** — `mdb_env_copythr` (the compacting-copy writer) passes the
+  `size_t` length straight to `WriteFile`, whose `nNumberOfBytesToWrite` is a
+  32-bit `DWORD`.  A length of exactly `2^32` truncates to `0` and the copy
+  fails.  (`mdb_env_copyfd1` already caps each call at `MAX_WRITE`; the
+  threaded writer did not.)
+
+## Fix
+
+* `mdb_page_flush`: on a non-negative short write, advance past the bytes
+  written (skip completed iovecs, adjust the first partial one) and loop via
+  `goto retry_write` until the whole page is written.
+* `mdb_env_copythr`: cap each `DO_WRITE` at `MAX_WRITE` (1 GiB on 64-bit),
+  matching `mdb_env_copyfd1`.
+
+## Reproducing
+
+`tests/large_write_test.py` (opt-in, `LMDB_TEST_LARGE=1`) stores a 2.25 GiB
+value, commits, reads it back, and round-trips it through a compacting copy.
+Before the fix the commit fails with `mdb_txn_commit: Input/output error` on
+Linux; after the fix both succeed.  It is skipped by default because it needs
+>2 GiB of RAM and disk.
+
+## Verification
+
+Verified end-to-end on both Linux and Windows: the opt-in test (a 2.25 GiB
+value committed, read back, and round-tripped through a compacting copy)
+passes on both, and the full suite is green on both.  The `mdb_env_copythr`
+cap is exercised on Windows at 2.25 GiB (> the 1 GiB `MAX_WRITE`).  The exact
+`2^32`-byte boundary that truncates the `WriteFile` `DWORD` occurs only for a
+value at `MAXDATASIZE` (~4 GiB); the cap prevents it but that specific size is
+not driven by a test.

--- a/misc/large-write.md
+++ b/misc/large-write.md
@@ -36,6 +36,15 @@ Before the fix the commit fails with `mdb_txn_commit: Input/output error` on
 Linux; after the fix both succeed.  It is skipped by default because it needs
 >2 GiB of RAM and disk.
 
+`misc/large-write-repro.c` is a standalone C reproducer against the raw
+LMDB API (for reporting upstream): it commits a 2.25 GiB value and prints
+`BUG REPRODUCED` (EIO) on unpatched LMDB, or `OK` once fixed.
+
+```
+gcc -O2 -o repro large-write-repro.c mdb.c midl.c -lpthread
+./repro /path/to/scratch
+```
+
 ## Verification
 
 Verified end-to-end on both Linux and Windows: the opt-in test (a 2.25 GiB

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ if patch_lmdb_source:
         'validate-md-depth',
         'validate-md-root',
         'win32-sparse-file',
+        'fix-large-write',
     ]
 
     if sys.platform.startswith('win'):

--- a/tests/large_write_test.py
+++ b/tests/large_write_test.py
@@ -1,0 +1,71 @@
+#
+# Regression test for the large single-write handling fixed in
+# lib/py-lmdb/fix-large-write.patch.
+#
+# A value that occupies a single overflow page larger than the platform per-
+# call write limit (~2 GiB on Linux for one write()/pwrite(); the 32-bit DWORD
+# length of WriteFile on Windows) was written in one call.  On Linux the short
+# return count was misread as a fatal error, so mdb_txn_commit failed with
+# EIO; the compacting-copy writer had the analogous issue.  The fix loops over
+# the short count in mdb_page_flush and caps the per-call size in the
+# mdb_env_copythr writer (matching mdb_env_copyfd1).
+#
+# Opt-in: needs a >2 GiB value in RAM plus >2 GiB of disk for the env (and
+# again for the compacting copy), so it is skipped unless LMDB_TEST_LARGE is
+# set.
+#
+
+import os
+import unittest
+
+import testlib
+import lmdb
+
+SKIP_PURE = (os.environ.get('LMDB_PURE') is not None or
+             os.environ.get('LMDB_FORCE_SYSTEM') is not None)
+RUN_LARGE = os.environ.get('LMDB_TEST_LARGE') is not None
+
+# 2.25 GiB: a single overflow page that exceeds the ~2 GiB single-write limit.
+_SIZE = 0x90000000
+
+
+def _make_value(size):
+    buf = bytearray(size)
+    buf[0:4] = b'HEAD'
+    buf[size - 4:size] = b'TAIL'
+    return buf
+
+
+@unittest.skipIf(SKIP_PURE, "fix lives in the patched bundled LMDB")
+@unittest.skipUnless(RUN_LARGE, "set LMDB_TEST_LARGE=1 (needs >2 GiB RAM + disk)")
+class LargeWriteTest(testlib.LmdbTest):
+    def test_commit_large_overflow_value(self):
+        _, env = testlib.temp_env(map_size=_SIZE + (512 << 20))
+        with env.begin(write=True) as txn:
+            self.assertTrue(txn.put(b'big', _make_value(_SIZE)))
+        with env.begin(buffers=True) as txn:
+            got = txn.get(b'big')
+            self.assertIsNotNone(got)
+            self.assertEqual(len(got), _SIZE)
+            self.assertEqual(bytes(got[0:4]), b'HEAD')
+            self.assertEqual(bytes(got[_SIZE - 4:_SIZE]), b'TAIL')
+
+    def test_compact_copy_large_overflow_value(self):
+        _, env = testlib.temp_env(map_size=_SIZE + (512 << 20))
+        with env.begin(write=True) as txn:
+            txn.put(b'big', _make_value(_SIZE))
+        dst = testlib.temp_dir()
+        env.copy(dst, compact=True)
+        denv = lmdb.open(dst, map_size=_SIZE + (512 << 20), readonly=True)
+        try:
+            with denv.begin(buffers=True) as txn:
+                got = txn.get(b'big')
+                self.assertIsNotNone(got)
+                self.assertEqual(len(got), _SIZE)
+                self.assertEqual(bytes(got[_SIZE - 4:_SIZE]), b'TAIL')
+        finally:
+            denv.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the large-single-write bug found while investigating #473: a single LMDB value larger than ~2 GiB (stored in one contiguous overflow page and written in one `mp_pages * psize` call) exceeds platform per-call write limits and was mishandled.

* **POSIX** — Linux `write()`/`pwrite()` transfers at most `0x7ffff000` (~2 GiB) and returns a **short count**. `mdb_page_flush` compared the short count to the requested size and treated it as fatal (`rc = EIO; "short write, filesystem full?"`), so **committing a >2 GiB value failed with `mdb_txn_commit: Input/output error`**.
* **Windows** — `mdb_env_copythr` (the compacting-copy writer) passes the `size_t` length straight to `WriteFile`, whose `nNumberOfBytesToWrite` is a 32-bit `DWORD`; a length of exactly `2^32` truncates to `0`. `mdb_env_copyfd1` already caps each call at `MAX_WRITE`, but the threaded writer did not.

## Fix (`lib/py-lmdb/fix-large-write.patch`)

* `mdb_page_flush`: on a non-negative short write, advance past the bytes written (skip completed iovecs, adjust the first partial one) and loop via `goto retry_write` until the page is fully written.
* `mdb_env_copythr`: cap each `DO_WRITE` at `MAX_WRITE` (1 GiB on 64-bit), matching `mdb_env_copyfd1`.

Delivered as a vendored patch registered in `setup.py`'s `patch_names`, consistent with the other LMDB modifications.

## Reproducing / testing

`tests/large_write_test.py` (opt-in `LMDB_TEST_LARGE=1`, skipped by default since it needs >2 GiB RAM + disk) stores a 2.25 GiB value, commits, reads it back, and round-trips it through a compacting copy.

Verified:
* **A/B on Linux**: pristine build fails the commit with `EIO`; patched build succeeds with correct readback.
* **Full suite green on Linux and Windows** (366 / 362 passed).
* **Opt-in large-write test passes on both Linux and Windows** (commit + compacting copy of 2.25 GiB).

The exact `2^32`-byte `WriteFile` `DWORD` boundary only occurs for a value at `MAXDATASIZE` (~4 GiB); the cap prevents it but that specific size isn't driven by a test. Details in `misc/large-write.md`.

## Relationship to #473

Complementary. #473 fixes the 32-bit multiply that computes overflow byte-lengths; this fixes the writes of those lengths. Both are needed before a near-`MAXDATASIZE` value round-trips end-to-end. Independent diffs (different functions); either can land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
