### PR TITLE
Fix Windows flush truncating >4 GiB overflow writes

### DIFF
--- a/lib/py-lmdb/fix-win-flush-large-write.patch
+++ b/lib/py-lmdb/fix-win-flush-large-write.patch
@@ -1,0 +1,40 @@
+diff --git a/libraries/liblmdb/mdb.c b/libraries/liblmdb/mdb.c
+--- a/libraries/liblmdb/mdb.c
++++ b/libraries/liblmdb/mdb.c
+@@ -3457,13 +3457,29 @@
+ 		 * system call.
+ 		 */
+ 		DPRINTF(("committing page %"Z"u", pgno));
+-		memset(&ov, 0, sizeof(ov));
+-		ov.Offset = pos & 0xffffffff;
+-		ov.OffsetHigh = pos >> 16 >> 16;
+-		if (!WriteFile(env->me_fd, dp, size, NULL, &ov)) {
+-			rc = ErrCode();
+-			DPRINTF(("WriteFile: %d", rc));
+-			return rc;
++		/* WriteFile length is a 32-bit DWORD, and a single overflow page can
++		 * exceed 4 GiB (size == psize * mp_pages for a value near
++		 * MAXDATASIZE), which would truncate.  Write in chunks of at most
++		 * MAX_WRITE, advancing the file offset each time. */
++		{
++			char *wptr = (char *)dp;
++			size_t wleft = size;
++			size_t wpos = pos;
++			while (wleft) {
++				DWORD wchunk = wleft > MAX_WRITE ? (DWORD)MAX_WRITE : (DWORD)wleft;
++				DWORD wdone = 0;
++				memset(&ov, 0, sizeof(ov));
++				ov.Offset = (DWORD)(wpos & 0xffffffff);
++				ov.OffsetHigh = (DWORD)(wpos >> 16 >> 16);
++				if (!WriteFile(env->me_fd, wptr, wchunk, &wdone, &ov)) {
++					rc = ErrCode();
++					DPRINTF(("WriteFile: %d", rc));
++					return rc;
++				}
++				wptr += wdone;
++				wleft -= wdone;
++				wpos += wdone;
++			}
+ 		}
+ #else
+ 		/* Write up to MDB_COMMIT_PAGES dirty pages at a time. */

--- a/misc/win-flush-large-write-repro.c
+++ b/misc/win-flush-large-write-repro.c
@@ -1,0 +1,102 @@
+/*
+ * Reproducer for: on Windows, mdb_page_flush() writes each overflow page with
+ * a single WriteFile() whose nNumberOfBytesToWrite is a 32-bit DWORD.  A value
+ * whose overflow extent (psize * mp_pages) reaches 2**32 -- a value a few KB
+ * below MAXDATASIZE -- has its length truncated; an extent of exactly 2**32
+ * truncates to 0, so WriteFile() writes nothing and the value is silently
+ * lost.  The commit still "succeeds" (a 0-byte WriteFile returns TRUE), so the
+ * bug shows up as a value that reads back as zeroes instead of its contents.
+ *
+ *   Unpatched:  "BUG REPRODUCED: value truncated/lost ..."   (exit 1)
+ *   Fixed:      "OK: committed and read back ... intact"     (exit 0)
+ *
+ * The bug is in the _WIN32 flush path, so it reproduces on Windows.  (On POSIX
+ * the same value exercises mdb_page_flush()'s short-write loop instead; that
+ * is PR #474.)  Needs a 64-bit build and ~4 GiB of RAM + disk.
+ *
+ * Build (MSVC, from a "x64 Native Tools" prompt, at the repo root):
+ *   cl /O2 /I lib misc\win-flush-large-write-repro.c build\lib\mdb.c ^
+ *      build\lib\midl.c /Fe:repro.exe /link advapi32.lib
+ * Build (gcc / MinGW or POSIX):
+ *   gcc -O2 -I lib -o repro misc/win-flush-large-write-repro.c \
+ *       lib/mdb.c lib/midl.c -lpthread
+ * Run:
+ *   repro [scratch-dir]
+ *
+ * Exit status: 0 = fixed/OK, 1 = bug reproduced, 2 = setup error.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#ifdef _WIN32
+#  include <direct.h>
+#  define MKDIR(d) _mkdir(d)
+#else
+#  include <sys/stat.h>
+#  define MKDIR(d) mkdir((d), 0755)
+#endif
+#include "lmdb.h"
+
+#define CHK(expr) do { int rc_ = (expr); if (rc_) { \
+    fprintf(stderr, "%s:%d: %s: %s\n", __FILE__, __LINE__, #expr, \
+            mdb_strerror(rc_)); return 2; } } while (0)
+
+int main(int argc, char **argv)
+{
+    const char *dir = argc > 1 ? argv[1] : "lw-repro-db";
+    /* Overflow extent psize*mp_pages == 2**32 on a 4 KiB-page system:
+     * WriteFile's DWORD length truncates 2**32 -> 0.  The value data stays
+     * below the 4 GiB file offset so the read-back itself is unaffected. */
+    const size_t VALSIZE = (size_t)0xFFFFF000UL;
+    MDB_env *env;
+    MDB_txn *txn;
+    MDB_dbi dbi;
+    MDB_val key, val, got;
+    unsigned char *p;
+    char *buf;
+
+    if (sizeof(size_t) < 8) {
+        fprintf(stderr, "This reproducer requires a 64-bit build.\n");
+        return 2;
+    }
+
+    MKDIR(dir);
+
+    buf = (char *)malloc(VALSIZE);
+    if (!buf) { fprintf(stderr, "malloc(%zu) failed\n", VALSIZE); return 2; }
+    memset(buf, 'x', VALSIZE);
+    memcpy(buf, "HEAD", 4);
+    memcpy(buf + VALSIZE - 4, "TAIL", 4);
+
+    CHK(mdb_env_create(&env));
+    CHK(mdb_env_set_mapsize(env, VALSIZE + (256UL << 20)));
+    CHK(mdb_env_open(env, dir, 0, 0664));
+    CHK(mdb_txn_begin(env, NULL, 0, &txn));
+    CHK(mdb_dbi_open(txn, NULL, 0, &dbi));
+    key.mv_data = (void *)"big"; key.mv_size = 3;
+    val.mv_data = buf;           val.mv_size = VALSIZE;
+    CHK(mdb_put(txn, dbi, &key, &val, 0));
+    CHK(mdb_txn_commit(txn));    /* the overflow-page WriteFile happens here */
+    free(buf);
+
+    CHK(mdb_txn_begin(env, NULL, MDB_RDONLY, &txn));
+    CHK(mdb_get(txn, dbi, &key, &got));
+    p = (unsigned char *)got.mv_data;
+    if (got.mv_size != VALSIZE ||
+        memcmp(p, "HEAD", 4) != 0 ||
+        memcmp(p + VALSIZE - 4, "TAIL", 4) != 0) {
+        fprintf(stderr,
+            "BUG REPRODUCED: value truncated/lost: size=%zu "
+            "head=%02x%02x%02x%02x tail=%02x%02x%02x%02x\n",
+            got.mv_size, p[0], p[1], p[2], p[3],
+            p[VALSIZE - 4], p[VALSIZE - 3], p[VALSIZE - 2], p[VALSIZE - 1]);
+        mdb_txn_abort(txn); mdb_env_close(env);
+        return 1;
+    }
+    mdb_txn_abort(txn);
+    mdb_env_close(env);
+
+    printf("OK: committed and read back %zu-byte value intact\n", VALSIZE);
+    return 0;
+}

--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ if patch_lmdb_source:
         'validate-md-root',
         'win32-sparse-file',
         'fix-large-write',
+        'fix-win-flush-large-write',
     ]
 
     if sys.platform.startswith('win'):

--- a/tests/large_write_test.py
+++ b/tests/large_write_test.py
@@ -46,6 +46,7 @@ class LargeWriteTest(testlib.LmdbTest):
         with env.begin(buffers=True) as txn:
             got = txn.get(b'big')
             self.assertIsNotNone(got)
+            assert got is not None  # narrow Optional for type-checkers
             self.assertEqual(len(got), _SIZE)
             self.assertEqual(bytes(got[0:4]), b'HEAD')
             self.assertEqual(bytes(got[_SIZE - 4:_SIZE]), b'TAIL')
@@ -61,10 +62,32 @@ class LargeWriteTest(testlib.LmdbTest):
             with denv.begin(buffers=True) as txn:
                 got = txn.get(b'big')
                 self.assertIsNotNone(got)
+                assert got is not None  # narrow Optional for type-checkers
                 self.assertEqual(len(got), _SIZE)
                 self.assertEqual(bytes(got[_SIZE - 4:_SIZE]), b'TAIL')
         finally:
             denv.close()
+
+    # A value whose overflow extent (psize * mp_pages) reaches 2**32 exercises
+    # the per-call write-length limit differently on each platform: the Linux
+    # ~2 GiB write() short-count (handled by mdb_page_flush's loop) and, on
+    # Windows, mdb_page_flush's single WriteFile whose length is a 32-bit DWORD
+    # -- 2**32 truncates to 0, so the whole page is written as 0 bytes and the
+    # value is lost.  Needs ~4 GiB of RAM/disk.
+    _EXTENT_SIZE = 0xFFFFF000  # psize*mp_pages == 2**32 for 4K/16K/64K pages
+
+    def test_commit_extent_at_2gib_boundary(self):
+        size = self._EXTENT_SIZE
+        _, env = testlib.temp_env(map_size=size + (256 << 20))
+        with env.begin(write=True) as txn:
+            self.assertTrue(txn.put(b'ext', _make_value(size)))
+        with env.begin(buffers=True) as txn:
+            got = txn.get(b'ext')
+            self.assertIsNotNone(got)
+            assert got is not None  # narrow Optional for type-checkers
+            self.assertEqual(len(got), size)
+            self.assertEqual(bytes(got[0:4]), b'HEAD')
+            self.assertEqual(bytes(got[size - 4:size]), b'TAIL')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Follow-up to #474 (which I flagged while adding the reproducer to #473). On Windows, `mdb_page_flush` writes each overflow page with a single

```c
WriteFile(env->me_fd, dp, size, NULL, &ov);
```

where `size = psize * mp_pages`. For a value near `MAXDATASIZE` (4 GiB − 1) that extent reaches or exceeds `2^32`, but `WriteFile`'s `nNumberOfBytesToWrite` is a 32-bit **`DWORD`** — so it truncates. An extent of **exactly `2^32` truncates to `0`**, and the entire overflow page is written as **zero bytes**, silently losing the value. (The `NULL` `lpNumberOfBytesWritten` also hid any partial write.)

#474 fixed the POSIX flush short-count and the Windows *copy* writer (`mdb_env_copythr`), but not this Windows *flush* path — so it surfaced when the #473 reproducer tried to commit a near-`MAXDATASIZE` value on Windows.

## Fix (`lib/py-lmdb/fix-win-flush-large-write.patch`)

Write the page in chunks of at most `MAX_WRITE` (1 GiB on 64-bit), advancing the `OVERLAPPED` offset and checking the bytes actually written — the same idiom `mdb_env_copyfd1` already uses and that #474 added to `mdb_env_copythr`. POSIX path unchanged. Registered last in `setup.py`'s `patch_names` (it applies after `fix-large-write.patch`).

## Testing

* **Builds clean** on Windows (MSVC — the `_WIN32` block actually compiles there) and Linux (patch applies; that block isn't compiled).
* **A/B on Windows** with a value whose overflow extent is exactly `2^32` (`0xFFFFF000`): on master the value comes back **all zeros** (even `HEAD` — `WriteFile(2^32)` wrote 0 bytes); with the fix it round-trips byte-for-byte.
* **`tests/large_write_test.py::…::test_commit_extent_at_2gib_boundary`** (opt-in `LMDB_TEST_LARGE=1`, needs ~4 GiB RAM/disk) covers it; passes on both Linux and Windows.
* **Full suite green** on both (366 Linux / 365 Windows), **pyright clean**.

## Note on the very top of `MAXDATASIZE`

A value in the last ~4 KiB below `MAXDATASIZE` (data crossing the 4 GiB file offset) still needs #473 as well — its `mdb_page_touch` COW-arithmetic (the `num * me_psize` wrap) corrupts the dirty page before it's ever flushed. This PR fixes the flush write itself; the test uses the extent-`2^32` case, which isolates this bug cleanly. With #473 + #474 + this, a full `MAXDATASIZE` round-trip works on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
