### PR TITLE
Fix set_mapsize() invalidating open database handles (#475)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,15 @@ Bug fixes
     context exit now also acquire the lock and run on the executor, so closing
     can no longer race an in-flight operation on the same transaction.
 
+- Fix ``Environment.set_mapsize()`` invalidating open database handles.
+    Since 2.2.0 (#443), calling ``set_mapsize()`` between transactions
+    invalidated all named- and main-database handles, so a handle opened
+    before the resize raised ``lmdb.Error: Database handle belongs to
+    another environment`` (CPython) or an invalid-dbi ``TypeError`` (CFFI)
+    on next use. Database handles hold only an integer ``MDB_dbi`` that
+    stays valid across the remap, so they are now preserved; only open
+    transactions and cursors are invalidated. (#475)
+
 Improvements
 ------------
 

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -853,11 +853,14 @@ class Environment:
             if self._env is _invalid:
                 raise Error("environment is closed")
 
-            # Phase 1: invalidate all child handles (txns, cursors).
-            # Mirrors close()'s Phase 1 but leaves _env valid.
+            # Phase 1: invalidate open transactions and cursors only.
+            # _Database handles are also env deps, but their MDB_dbi stays
+            # valid across the remap, so they must survive (issue #475).
             txn_handles = []
             if self._deps:
                 for dep in self._deps:
+                    if isinstance(dep, _Database):
+                        continue
                     if hasattr(dep, '_deps') and dep._deps:
                         for child in dep._deps:
                             if hasattr(child, '_cur'):
@@ -871,9 +874,11 @@ class Environment:
                     if hasattr(dep, '_dbi'):
                         dep._dbi = _invalid
                 for dep in list(self._deps):
+                    if isinstance(dep, _Database):
+                        continue
                     if hasattr(dep, '_deps') and dep._deps:
                         dep._deps.clear()
-                self._deps.clear()
+                    self._deps.discard(dep)
 
             # Phase 2: abort collected txns.
             for txn in txn_handles:
@@ -884,33 +889,14 @@ class Environment:
                 while self._spare_txns:
                     _lib.mdb_txn_abort(self._spare_txns.pop())
 
-            # Clear cached DB handles — they reference the old mapping.
-            if self._dbs:
-                self._dbs.clear()
-            self._db = None
-
-            # Now safe to remap.
+            # Now safe to remap.  Cached DB handles (_dbs/_db) are preserved:
+            # mdb_env_set_mapsize does not touch the dbi table.
             rc = _lib.mdb_env_set_mapsize(self._env, map_size)
             if rc:
                 # Remap failed — env is unusable.
                 self._env = _invalid
                 raise _error("mdb_env_set_mapsize", rc)
 
-            # Re-initialize deps tracking and re-open the main DB handle.
-            self._deps = set()
-            with self.begin(db=object()) as txn:
-                self._db = _Database(
-                    env=self,
-                    txn=txn,
-                    name=None,
-                    reverse_key=False,
-                    dupsort=False,
-                    create=True,
-                    integerkey=False,
-                    integerdup=False,
-                    dupfixed=False
-                )
-            self._dbs = {None: self._db}
             self._spare_txns = []
 
     def close(self):

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -381,6 +381,53 @@ static void invalidate_mark(struct lmdb_object *parent)
 #define INVALIDATE(parent) invalidate((void *)parent);
 #define INVALIDATE_MARK(parent) invalidate_mark((void *)parent);
 
+/**
+ * Like invalidate()/invalidate_mark(), but restricted to transaction children
+ * (and, recursively, their cursors).  Named- and main-database handles
+ * (DbObject) are also direct children of the environment, but they hold only
+ * an integer MDB_dbi that stays valid across mdb_env_set_mapsize's
+ * munmap/mmap.  Only transactions and cursors hold pointers into the old
+ * mapping, so only they must be invalidated on resize.  Invalidating a
+ * database handle would set db->env = NULL and break the caller's still-valid
+ * handle.  Issue #475.
+ */
+static void invalidate_mark_txns(struct lmdb_object *parent)
+{
+    struct lmdb_object *child = parent->children.next;
+    while(child) {
+        if(Py_TYPE(child) == &PyTransaction_Type) {
+            child->valid = 0;
+            invalidate_mark(child);
+        }
+        child = child->siblings.next;
+    }
+}
+
+static void invalidate_txns(struct lmdb_object *parent)
+{
+    struct lmdb_object *child = parent->children.next;
+    PyObject *held_ref = NULL;
+    while(child) {
+        struct lmdb_object *next = child->siblings.next;
+        /* tp_clear may release the GIL, allowing another thread to
+         * Py_DECREF both `child` and `next` to zero.  Hold temporary
+         * references to prevent use-after-free (see invalidate()). */
+        Py_XINCREF((PyObject *) next);
+        Py_INCREF((PyObject *) child);
+        if(Py_TYPE(child) == &PyTransaction_Type) {
+            Py_TYPE(child)->tp_clear((PyObject *) child);
+        }
+        Py_DECREF((PyObject *) child);
+        Py_XDECREF(held_ref);
+        held_ref = (PyObject *) next;
+        child = next;
+    }
+    Py_XDECREF(held_ref);
+}
+
+#define INVALIDATE_TXNS(parent) invalidate_txns((void *)parent);
+#define INVALIDATE_MARK_TXNS(parent) invalidate_mark_txns((void *)parent);
+
 
 /* ---------- */
 /* Exceptions */
@@ -2295,10 +2342,11 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
-    /* Phase 1: quickly mark all children invalid so no new LMDB operations
-     * can start on existing transactions/cursors.  The env itself stays
-     * valid (we do NOT set self->valid = 0). */
-    INVALIDATE_MARK(self)
+    /* Phase 1: quickly mark open transactions (and their cursors) invalid so
+     * no new LMDB operations can start on them.  Database handles are left
+     * valid — their MDB_dbi survives the remap (issue #475).  The env itself
+     * stays valid (we do NOT set self->valid = 0). */
+    INVALIDATE_MARK_TXNS(self)
 
     /* Wait for in-flight LMDB operations to complete.  Same pattern as
      * env_clear — see issue #180. */
@@ -2312,9 +2360,8 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
 
     /* Phase 2: abort all child transactions and close cursors.  This must
      * happen while the old mmap is still valid so mdb_txn_abort can
-     * safely touch the pages it needs to. */
-    INVALIDATE(self)
-    Py_CLEAR(self->main_db);
+     * safely touch the pages it needs to.  Database handles are preserved. */
+    INVALIDATE_TXNS(self)
 
     /* Abort the spare read-only transaction — it holds references to the
      * old memory map. */
@@ -2331,13 +2378,6 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
          * so subsequent operations raise a clear error. */
         self->valid = 0;
         return err_set("mdb_env_set_mapsize", rc);
-    }
-
-    /* Re-create the main database handle for the new mapping. */
-    self->main_db = txn_db_from_name(self, NULL, 0);
-    if(! self->main_db) {
-        self->valid = 0;
-        return NULL;
     }
 
     Py_RETURN_NONE;

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -349,6 +349,44 @@ class SetMapSizeTest(unittest.TestCase):
             assert txn.get(b'key') == b'val'
         assert env.info()['map_size'] == PAGE_SIZE * 32
 
+    def test_retained_named_db_handle_survives_resize(self):
+        """A named-db handle opened before set_mapsize stays usable after it.
+
+        Regression for issue #475: set_mapsize invalidated database handles,
+        so a retained handle raised "Database handle belongs to another
+        environment" (cpython) or an invalid-dbi error (cffi)."""
+        _, env = testlib.temp_env(map_size=PAGE_SIZE * 8, max_dbs=4)
+        db = env.open_db(b'mydb')
+        with env.begin(write=True, db=db) as txn:
+            txn.put(b'k', b'v')
+
+        env.set_mapsize(PAGE_SIZE * 16)
+
+        # Reuse the ORIGINAL handle — do not re-open.
+        with env.begin(write=True, db=db) as txn:
+            with txn.cursor(db) as cursor:
+                assert cursor.set_key(b'k')
+                assert cursor.value() == b'v'
+            txn.put(b'k2', b'v2', db=db)
+        with env.begin(db=db) as txn:
+            assert txn.get(b'k') == b'v'
+            assert txn.get(b'k2') == b'v2'
+
+    def test_retained_main_db_handle_survives_resize(self):
+        """The default (main) database is usable through repeated resizes,
+        mirroring the report in issue #475 (commit, resize, keep writing)."""
+        _, env = testlib.temp_env(map_size=PAGE_SIZE * 8)
+        for i in range(4):
+            with env.begin(write=True) as txn:
+                with txn.cursor() as cursor:
+                    cursor.put(str(i).encode(), b'word', overwrite=False)
+            map_pages = env.info()['last_pgno'] + 1
+            env.set_mapsize((map_pages + 8) * PAGE_SIZE)
+
+        with env.begin() as txn:
+            for i in range(4):
+                assert txn.get(str(i).encode()) == b'word'
+
 
 class CloseTest(unittest.TestCase):
     def tearDown(self):


### PR DESCRIPTION
## Summary

Fixes #475.

Since #443 (released in 2.2.0), `Environment.set_mapsize()` invalidated **all** of the environment's child handles before remapping — including named- and main-database handles. A database handle opened *before* the resize then failed on next use, even though the caller never closed it:

- **CPython backend:** `lmdb.Error: Database handle belongs to another environment.`
- **CFFI backend:** `TypeError: expected integer, got Some_LMDB_Resource_That_Was_Deleted_Or_Closed object`

This is exactly the reporter's scenario: open a named DB, commit, `set_mapsize()`, keep using the same handle.

## Root cause

`set_mapsize()` calls `munmap`/`mmap`, which dangles any pointer into the old mapping. The `#443` invalidation correctly aborts open transactions and closes cursors (which *do* hold such pointers), but it did so by walking **every** env child, and database handles are env children too. A database handle holds only an integer `MDB_dbi`, and `mdb_env_set_mapsize` does not touch the dbi table — so database handles stay valid across the remap and must be preserved.

The `#443` code papered over this for the *main* DB by clearing and re-creating `main_db` afterward, but named databases (and any retained reference to the main DB object) were left invalid.

## Fix

- **CPython** (`lmdb/cpython.c`): add `invalidate_txns()` / `invalidate_mark_txns()` that walk the env's children but only clear `TransObject` children. Cursors are still invalidated — recursively, via `trans_clear`. Drops the now-unneeded `Py_CLEAR`/re-create of `main_db`.
- **CFFI** (`lmdb/cffi.py`): skip `_Database` deps during invalidation, and stop clearing/rebuilding `_dbs` / `_db`.

Semantics are unchanged for the documented behavior: open **transactions, cursors, and iterators** are still invalidated by `set_mapsize()`; a write transaction is still rejected.

## Tests

Adds two regression tests in `tests/env_test.py::SetMapSizeTest`:

- `test_retained_named_db_handle_survives_resize` — retains a named-db handle across the resize (the reporter's case).
- `test_retained_main_db_handle_survives_resize` — mirrors the report's commit/resize/keep-writing loop on the main DB.

The named-db test fails before this change on **both** backends and passes after. Full suite: 362 passed on the CPython extension; the `SetMapSizeTest` group (12 tests) passes on both the CPython extension and CFFI/PyPy.

The reporter's `increase.py` now runs cleanly on Linux with both backends (I could not test Windows, but the bug reproduced identically on Linux, so it was never Windows-specific — the reporter simply couldn't obtain non-Windows 2.2.x builds).
