### PR TITLE
Fix races between set_mapsize() and concurrent operations (#475)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,21 @@ Bug fixes
     stays valid across the remap, so they are now preserved; only open
     transactions and cursors are invalidated. (#475)
 
+- Fix races between ``Environment.set_mapsize()`` and concurrent operations
+    on other threads. An operation starting during the resize's remap window
+    could touch the old memory map after ``munmap`` (crash or corruption); a
+    write-transaction abort racing the resize could deadlock it or leave a
+    transaction alive at remap time (failing the resize and invalidating the
+    environment); and in the CFFI backend a write transaction beginning
+    during the resize could orphan its thread-id record, deadlocking a later
+    ``close()``. LMDB operations that would race a resize now fail fast with
+    ``lmdb.Error`` instead; retry them after the resize completes. The CFFI
+    backend now also serializes ``Transaction.get``/``put``/``delete``/
+    ``stat``/``drop`` and the environment-level ``stat``/``info``/``sync``/
+    ``copy``/``copyfd``/``readers``/``reader_check`` against
+    ``close()``/``set_mapsize()``, closing long-standing crash races with
+    ``close()`` as well. (#475)
+
 Improvements
 ------------
 

--- a/lmdb/cffi.py
+++ b/lmdb/cffi.py
@@ -853,6 +853,16 @@ class Environment:
             if self._env is _invalid:
                 raise Error("environment is closed")
 
+            # Re-check under _close_lock: a write transaction begin holds
+            # the lock, so one may have completed between the unlocked
+            # check above and our acquisition.  Invalidating a write txn
+            # here would leave its _write_txn_tid orphaned — the owner's
+            # abort() sees _txn falsy (_invalid) and returns without
+            # clearing it, deadlocking a later close().  Issue #475.
+            if self._write_txn_tid:
+                raise Error(
+                    "Cannot set_mapsize while a write transaction is active")
+
             # Phase 1: invalidate open transactions and cursors only.
             # _Database handles are also env deps, but their MDB_dbi stays
             # valid across the remap, so they must survive (issue #475).
@@ -1032,14 +1042,17 @@ class Environment:
             raise TypeError("txn argument only compatible with compact=True")
 
         encoded = path.encode(sys.getfilesystemencoding())
-        if _have_patched_lmdb:
-            rc = _lib.mdb_env_copy3(self._env, encoded, flags, txn._txn if txn else _ffi.NULL)
-            if rc:
-                raise _error("mdb_env_copy3", rc)
-        else:
-            rc = _lib.mdb_env_copy2(self._env, encoded, flags)
-            if rc:
-                raise _error("mdb_env_copy2", rc)
+        # Hold _close_lock so close() or set_mapsize() cannot free/remap the
+        # environment while the copy is reading it.  Issue #475.
+        with self._close_lock:
+            if _have_patched_lmdb:
+                rc = _lib.mdb_env_copy3(self._env, encoded, flags, txn._txn if txn else _ffi.NULL)
+                if rc:
+                    raise _error("mdb_env_copy3", rc)
+            else:
+                rc = _lib.mdb_env_copy2(self._env, encoded, flags)
+                if rc:
+                    raise _error("mdb_env_copy2", rc)
 
     def copyfd(self, fd, compact=False, txn=None):
         """Copy a consistent version of the environment to file descriptor
@@ -1070,14 +1083,17 @@ class Environment:
         if txn and not flags:
             raise TypeError("txn argument only compatible with compact=True")
 
-        if _have_patched_lmdb:
-            rc = _lib.mdb_env_copyfd3(self._env, fd, flags, txn._txn if txn else _ffi.NULL)
-            if rc:
-                raise _error("mdb_env_copyfd3", rc)
-        else:
-            rc = _lib.mdb_env_copyfd2(self._env, fd, flags)
-            if rc:
-                raise _error("mdb_env_copyfd2", rc)
+        # Hold _close_lock so close() or set_mapsize() cannot free/remap the
+        # environment while the copy is reading it.  Issue #475.
+        with self._close_lock:
+            if _have_patched_lmdb:
+                rc = _lib.mdb_env_copyfd3(self._env, fd, flags, txn._txn if txn else _ffi.NULL)
+                if rc:
+                    raise _error("mdb_env_copyfd3", rc)
+            else:
+                rc = _lib.mdb_env_copyfd2(self._env, fd, flags)
+                if rc:
+                    raise _error("mdb_env_copyfd2", rc)
 
     def sync(self, force=False):
         """Flush the data buffers to disk.
@@ -1095,9 +1111,12 @@ class Environment:
             environment was opened with `sync=False` the flushes will be
             omitted, and with `map_async=True` they will be asynchronous.
         """
-        rc = _lib.mdb_env_sync(self._env, force)
-        if rc:
-            raise _error("mdb_env_sync", rc)
+        # Hold _close_lock so close()/set_mapsize() cannot free or remap the
+        # environment during the flush.  Issue #475.
+        with self._close_lock:
+            rc = _lib.mdb_env_sync(self._env, force)
+            if rc:
+                raise _error("mdb_env_sync", rc)
 
     def _convert_stat(self, st):
         """Convert a MDB_stat to a dict.
@@ -1134,9 +1153,11 @@ class Environment:
         <http://lmdb.tech/doc/group__mdb.html#gaf881dca452050efbd434cd16e4bae255>`_
         """
         st = _ffi.new('MDB_stat *')
-        rc = _lib.mdb_env_stat(self._env, st)
-        if rc:
-            raise _error("mdb_env_stat", rc)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._close_lock:
+            rc = _lib.mdb_env_stat(self._env, st)
+            if rc:
+                raise _error("mdb_env_stat", rc)
         return self._convert_stat(st)
 
     def info(self):
@@ -1165,9 +1186,11 @@ class Environment:
         <http://lmdb.tech/doc/group__mdb.html#ga18769362c7e7d6cf91889a028a5c5947>`_
         """
         info = _ffi.new('MDB_envinfo *')
-        rc = _lib.mdb_env_info(self._env, info)
-        if rc:
-            raise _error("mdb_env_info", rc)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._close_lock:
+            rc = _lib.mdb_env_info(self._env, info)
+            if rc:
+                raise _error("mdb_env_info", rc)
         return {
             "map_addr": int(_ffi.cast('long', info.me_mapaddr)),
             "map_size": info.me_mapsize,
@@ -1218,9 +1241,11 @@ class Environment:
         the reader lock table."""
         _callbacks.msg_func = []
         try:
-            rc = _lib.mdb_reader_list(self._env, _msg_func, _ffi.NULL)
-            if rc:
-                raise _error("mdb_reader_list", rc)
+            # Issue #475: serialize against close()/set_mapsize().
+            with self._close_lock:
+                rc = _lib.mdb_reader_list(self._env, _msg_func, _ffi.NULL)
+                if rc:
+                    raise _error("mdb_reader_list", rc)
             return "".join(_callbacks.msg_func)
         finally:
             del _callbacks.msg_func
@@ -1230,9 +1255,11 @@ class Environment:
         crashed process. Returns the number of stale entries that were cleared.
         """
         reaped = _ffi.new('int[]', 1)
-        rc = _lib.mdb_reader_check(self._env, reaped)
-        if rc:
-            raise _error('mdb_reader_check', rc)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._close_lock:
+            rc = _lib.mdb_reader_check(self._env, reaped)
+            if rc:
+                raise _error('mdb_reader_check', rc)
         return reaped[0]
 
     def open_db(self, key=None, txn=None, reverse_key=False, dupsort=False,
@@ -1625,7 +1652,9 @@ class Transaction:
         read-only transaction, this corresponds to the snapshot being read;
         concurrent readers will frequently have the same transaction ID.
         """
-        return _lib.mdb_txn_id(self._txn)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._pyenv._close_lock:
+            return _lib.mdb_txn_id(self._txn)
 
     def stat(self, db=None):
         """stat(db=None)
@@ -1637,7 +1666,9 @@ class Transaction:
         if db is None:
             db = self._db
         st = _ffi.new('MDB_stat *')
-        rc = _lib.mdb_stat(self._txn, db._dbi, st)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._pyenv._close_lock:
+            rc = _lib.mdb_stat(self._txn, db._dbi, st)
         if rc:
             raise _error('mdb_stat', rc)
         return self._pyenv._convert_stat(st)
@@ -1652,7 +1683,9 @@ class Transaction:
         """
         while db._deps:
             db._deps.pop()._invalidate()
-        rc = _lib.mdb_drop(self._txn, db._dbi, delete)
+        # Issue #475: serialize against close()/set_mapsize().
+        with self._pyenv._close_lock:
+            rc = _lib.mdb_drop(self._txn, db._dbi, delete)
         self._mutations += 1
         if rc:
             raise _error("mdb_drop", rc)
@@ -1747,15 +1780,18 @@ class Transaction:
         Equivalent to `mdb_get()
         <http://lmdb.tech/doc/group__mdb.html#ga8bf10cd91d3f3a83a34d04ce6b07992d>`_
         """
-        rc = _lib.pymdb_get(self._txn, (db or self._db)._dbi,
-                            key, len(key), self._val)
-        if rc:
-            if rc == _lib.MDB_NOTFOUND:
-                return default
-            raise _error("mdb_cursor_get", rc)
+        # Hold _close_lock so close()/set_mapsize() cannot abort the txn or
+        # remap the environment during the C call.  Issue #475.
+        with self._pyenv._close_lock:
+            rc = _lib.pymdb_get(self._txn, (db or self._db)._dbi,
+                                key, len(key), self._val)
+            if rc:
+                if rc == _lib.MDB_NOTFOUND:
+                    return default
+                raise _error("mdb_cursor_get", rc)
 
-        preload(self._val)
-        return self._to_py(self._val)
+            preload(self._val)
+            return self._to_py(self._val)
 
     def put(self, key, value, dupdata=True, overwrite=True, append=False,
             db=None):
@@ -1799,8 +1835,11 @@ class Transaction:
         if append:
             flags |= _lib.MDB_APPEND
 
-        rc = _lib.pymdb_put(self._txn, (db or self._db)._dbi,
-                            key, len(key), value, len(value), flags)
+        # Hold _close_lock so close()/set_mapsize() cannot abort the txn or
+        # remap the environment during the C call.  Issue #475.
+        with self._pyenv._close_lock:
+            rc = _lib.pymdb_put(self._txn, (db or self._db)._dbi,
+                                key, len(key), value, len(value), flags)
         self._mutations += 1
         if rc:
             if rc == _lib.MDB_KEYEXIST:
@@ -1847,8 +1886,11 @@ class Transaction:
         if value is None:  # for bug-compatibility with cpython impl
             value = EMPTY_BYTES
 
-        rc = _lib.pymdb_del(self._txn, (db or self._db)._dbi,
-                            key, len(key), value, len(value))
+        # Hold _close_lock so close()/set_mapsize() cannot abort the txn or
+        # remap the environment during the C call.  Issue #475.
+        with self._pyenv._close_lock:
+            rc = _lib.pymdb_del(self._txn, (db or self._db)._dbi,
+                                key, len(key), value, len(value))
         self._mutations += 1
         if rc:
             if rc == _lib.MDB_NOTFOUND:

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -55,7 +55,6 @@
 
 #ifndef _WIN32
 #include <pthread.h>
-#include <unistd.h> /* usleep */
 #endif
 
 #include "lmdb.h"
@@ -193,23 +192,10 @@ struct EnvObject {
     unsigned long write_txn_tid;
     /** Resolved path used to track this env in open_env_paths. */
     PyObject *open_path;
-    /** Count of in-flight LMDB operations (GIL released).  env_clear waits
-     *  for this to reach 0 before calling mdb_env_close.  Issue #180. */
+    /** Count of in-flight LMDB operations (GIL released).  env_clear and
+     *  set_mapsize wait for this to reach 0 before closing/remapping the
+     *  env.  Issue #180. */
     int active_ops;
-    /** Lock used to block-wait for active_ops to reach 0 instead of
-     *  spinning.  Allocated in locked state; released when active_ops
-     *  decrements to 0 and active_ops_waiter is set.  Issue #180. */
-    PyThread_type_lock active_ops_lock;
-    /** 1 if a thread is blocked waiting for active_ops to reach 0. */
-    int active_ops_waiter;
-    /** Lock used to block-wait in close() for another thread to release
-     *  an active write transaction (so its robust write mutex is unlocked
-     *  on the owning thread before the lock file is unmapped).  Allocated
-     *  in locked state; released by the owning thread after it aborts or
-     *  commits the write txn, when write_txn_waiter is set.  Issue #465. */
-    PyThread_type_lock write_txn_lock;
-    /** 1 if a thread is blocked in close() waiting for the write txn. */
-    int write_txn_waiter;
     /** 1 while set_mapsize() is inside its invalidate/remap critical
      *  section.  New GIL-releasing LMDB operations fail fast with EINVAL
      *  until the resize completes (see ENV_RESIZE_BLOCKED).  Issue #475. */
@@ -218,6 +204,28 @@ struct EnvObject {
      *  re-entry (e.g. a destructor running during invalidation, while the
      *  old map is still valid) passes through instead of failing. */
     unsigned long resize_tid;
+    /** 1 once ops_mutex/ops_cond below are initialized (guards teardown
+     *  on env_new error paths). */
+    int ops_sync_ready;
+    /** Mutex + condition variable guarding writes to active_ops,
+     *  write_txn_tid and resizing, and waking their waiters: env_clear's
+     *  operation drain, its issue-#465 write-txn wait and its wait for a
+     *  concurrent resize, trans_abort's child-operation wait, and
+     *  set_mapsize's drains.  A condition variable (rather than the
+     *  previous single-slot PyThread lock handoff) supports multiple
+     *  concurrent waiters: e.g. a write-transaction abort and a
+     *  set_mapsize can drain simultaneously without a lost wakeup.
+     *  Broadcasts happen when active_ops reaches 0, when write_txn_tid
+     *  clears, and when a resize completes.  All writes to the guarded
+     *  fields also happen with the GIL held, so GIL-holding readers need
+     *  not take the mutex.  Issues #180, #465, #475. */
+#ifdef _WIN32
+    CRITICAL_SECTION ops_mutex;
+    CONDITION_VARIABLE ops_cond;
+#else
+    pthread_mutex_t ops_mutex;
+    pthread_cond_t ops_cond;
+#endif
 };
 
 /** TransObject.flags bitfield values. */
@@ -761,57 +769,92 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
     out = (e); \
     Py_END_ALLOW_THREADS
 
-/* ACTIVE_OPS_DEC: decrement active_ops and signal the waiter lock if it
- * reaches 0 and someone is waiting.  Must be called with the GIL held.
- * Issue #180. */
-#define ACTIVE_OPS_DEC(_env) \
+/* Primitive wrappers for the env's ops_mutex/ops_cond (see EnvObject).
+ * The mutex is a leaf lock: held only for brief field updates or inside
+ * ENV_WAIT_WHILE — never while acquiring the GIL or calling into LMDB or
+ * Python, so no lock-order cycle with the GIL is possible. */
+#ifdef _WIN32
+#define ENV_SYNC_LOCK(_env)      EnterCriticalSection(&(_env)->ops_mutex)
+#define ENV_SYNC_UNLOCK(_env)    LeaveCriticalSection(&(_env)->ops_mutex)
+#define ENV_SYNC_WAIT(_env) \
+    SleepConditionVariableCS(&(_env)->ops_cond, &(_env)->ops_mutex, INFINITE)
+#define ENV_SYNC_BROADCAST(_env) WakeAllConditionVariable(&(_env)->ops_cond)
+#else
+#define ENV_SYNC_LOCK(_env)      pthread_mutex_lock(&(_env)->ops_mutex)
+#define ENV_SYNC_UNLOCK(_env)    pthread_mutex_unlock(&(_env)->ops_mutex)
+#define ENV_SYNC_WAIT(_env) \
+    pthread_cond_wait(&(_env)->ops_cond, &(_env)->ops_mutex)
+#define ENV_SYNC_BROADCAST(_env) pthread_cond_broadcast(&(_env)->ops_cond)
+#endif
+
+/* ENV_WAIT_WHILE: block (GIL released) until `cond` becomes false.  `cond`
+ * is evaluated under ops_mutex, so it may only reference fields whose
+ * writes take the mutex (active_ops, write_txn_tid, resizing/resize_tid)
+ * and thread-locals.  Multiple threads may wait concurrently; every state
+ * change broadcasts.  On return the GIL has been reacquired, and GIL-
+ * guarded state may have changed meanwhile — callers needing a GIL-stable
+ * predicate must re-check and loop.  Issues #180, #465, #475. */
+#define ENV_WAIT_WHILE(_env, cond) \
     do { \
-        if(--(_env)->active_ops == 0 && (_env)->active_ops_waiter) { \
-            (_env)->active_ops_waiter = 0; \
-            PyThread_release_lock((_env)->active_ops_lock); \
+        Py_BEGIN_ALLOW_THREADS \
+        ENV_SYNC_LOCK(_env); \
+        while(cond) { \
+            ENV_SYNC_WAIT(_env); \
         } \
+        ENV_SYNC_UNLOCK(_env); \
+        Py_END_ALLOW_THREADS \
     } while(0)
 
-/* NOTIFY_WRITE_TXN_DONE: wake a thread blocked in env_clear waiting for
- * this (owning) thread to release its write transaction.  MUST be called
- * with the GIL held and only AFTER the write txn's mutex has been
- * released (i.e. after mdb_txn_abort/commit completes), so the waiter
- * does not unmap the lock file while the robust mutex is still held.
- * Issue #465. */
-#define NOTIFY_WRITE_TXN_DONE(_env) \
+/* ACTIVE_OPS_INC/DEC: adjust the in-flight operation count.  Must be
+ * called with the GIL held; the mutex makes the update visible to
+ * non-GIL-holding waiters in ENV_WAIT_WHILE.  Issue #180. */
+#define ACTIVE_OPS_INC(_env) \
     do { \
-        if((_env)->write_txn_waiter) { \
-            (_env)->write_txn_waiter = 0; \
-            PyThread_release_lock((_env)->write_txn_lock); \
+        ENV_SYNC_LOCK(_env); \
+        (_env)->active_ops++; \
+        ENV_SYNC_UNLOCK(_env); \
+    } while(0)
+
+#define ACTIVE_OPS_DEC(_env) \
+    do { \
+        ENV_SYNC_LOCK(_env); \
+        if(--(_env)->active_ops == 0) { \
+            ENV_SYNC_BROADCAST(_env); \
         } \
+        ENV_SYNC_UNLOCK(_env); \
+    } while(0)
+
+/* CLEAR_WRITE_TXN_TID: record that this thread's write transaction is
+ * fully released, waking env_clear's issue-#465 wait and set_mapsize's
+ * drain.  MUST be called with the GIL held and only AFTER the write txn's
+ * mutex has been released (i.e. after mdb_txn_abort/commit completes), so
+ * a waiter does not unmap the lock file, or remap the data file, while
+ * the transaction is still live.  Issues #465, #475. */
+#define CLEAR_WRITE_TXN_TID(_env) \
+    do { \
+        ENV_SYNC_LOCK(_env); \
+        (_env)->write_txn_tid = 0; \
+        ENV_SYNC_BROADCAST(_env); \
+        ENV_SYNC_UNLOCK(_env); \
+    } while(0)
+
+/* SET_WRITE_TXN_TID: record this thread as the write-txn owner.  Must be
+ * called with the GIL held; mutex-protected for ENV_WAIT_WHILE readers. */
+#define SET_WRITE_TXN_TID(_env) \
+    do { \
+        ENV_SYNC_LOCK(_env); \
+        (_env)->write_txn_tid = (unsigned long) PyThread_get_thread_ident(); \
+        ENV_SYNC_UNLOCK(_env); \
     } while(0)
 
 /* ENV_UNLOCKED: release GIL for an LMDB call, holding the env's active_ops
  * counter to prevent env_clear from closing the env underneath us.  The
  * counter is incremented while the GIL is still held (so env_clear can't
  * start between our valid-check and the increment), and decremented after
- * we reacquire the GIL.  See issue #180. */
-/* ENV_UNLOCKED: release GIL for an LMDB call.  The _env expression is
- * evaluated once while the GIL is held and saved to a local, so pointer
- * chains like self->trans->env remain valid for ACTIVE_OPS_DEC even if
- * another thread NULLs an intermediate pointer during the GIL release.
- * Issue #180. */
-/* MILLISLEEP: sleep ~1ms with the GIL released; used by polling waits. */
-#ifdef _WIN32
-#define MILLISLEEP() \
-    do { \
-        Py_BEGIN_ALLOW_THREADS \
-        Sleep(1); \
-        Py_END_ALLOW_THREADS \
-    } while(0)
-#else
-#define MILLISLEEP() \
-    do { \
-        Py_BEGIN_ALLOW_THREADS \
-        usleep(1000); \
-        Py_END_ALLOW_THREADS \
-    } while(0)
-#endif
+ * we reacquire the GIL.  The _env expression is evaluated once while the
+ * GIL is held and saved to a local, so pointer chains like
+ * self->trans->env remain valid for ACTIVE_OPS_DEC even if another thread
+ * NULLs an intermediate pointer during the GIL release.  Issue #180. */
 
 /* ENV_RESIZE_BLOCKED: true when another thread is inside set_mapsize()'s
  * invalidate/remap critical section.  A new GIL-releasing LMDB operation
@@ -834,7 +877,7 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
             out = EINVAL; \
         } \
         else { \
-            _saved_env->active_ops++; \
+            ACTIVE_OPS_INC(_saved_env); \
             Py_BEGIN_ALLOW_THREADS \
             out = (e); \
             Py_END_ALLOW_THREADS \
@@ -857,7 +900,7 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
     do { \
         EnvObject *_saved_env = (_env); \
         if(! _saved_env->resizing) { \
-            _saved_env->active_ops++; \
+            ACTIVE_OPS_INC(_saved_env); \
             Py_BEGIN_ALLOW_THREADS \
             preload(_rc, _data, _size); \
             Py_END_ALLOW_THREADS \
@@ -1172,7 +1215,7 @@ make_trans(EnvObject *env, DbObject *db, TransObject *parent, int write,
             if(rc) {
                 return err_set("mdb_txn_begin", rc);
             }
-            env->write_txn_tid = PyThread_get_thread_ident();
+            SET_WRITE_TXN_TID(env);
         } else {
             /* Read txns and child txns: hold GIL during mdb_txn_begin to
              * prevent race with env_clear.  Issue #180. */
@@ -1186,9 +1229,8 @@ make_trans(EnvObject *env, DbObject *db, TransObject *parent, int write,
     if(! ((self = PyObject_New(TransObject, &PyTransaction_Type)))) {
         mdb_txn_abort(txn);
         if(write && !parent) {
-            env->write_txn_tid = 0;
-            /* Mutex released; wake any close() waiting on it.  #465. */
-            NOTIFY_WRITE_TXN_DONE(env);
+            /* Mutex released; wakes any close() waiting on it.  #465. */
+            CLEAR_WRITE_TXN_TID(env);
         }
         return NULL;
     }
@@ -1441,17 +1483,19 @@ static int
 env_clear(EnvObject *self)
 {
     MDB_txn * txn;
+    unsigned long me = (unsigned long) PyThread_get_thread_ident();
 
     MDEBUG("env_clear")
 
     /* If another thread is inside set_mapsize's critical section, wait
-     * (by polling — the active_ops waiter protocol is single-waiter) for
-     * it to finish before tearing the env down, so the two invalidation
-     * walks cannot interleave.  Same-thread re-entry (a destructor during
-     * the resize's invalidation phase) passes through.  set_mapsize never
-     * waits on close, so this cannot deadlock.  Issue #475. */
+     * for it to finish before tearing the env down, so the two
+     * invalidation walks cannot interleave.  Same-thread re-entry (a
+     * destructor during the resize's invalidation phase) passes through.
+     * set_mapsize never waits on close, so this cannot deadlock.  The
+     * outer loop re-checks under the GIL in case a new resize started
+     * between the wait ending and us reacquiring the GIL.  Issue #475. */
     while(ENV_RESIZE_BLOCKED(self)) {
-        MILLISLEEP();
+        ENV_WAIT_WHILE(self, self->resizing && self->resize_tid != me);
     }
 
     self->valid = 0;
@@ -1459,16 +1503,10 @@ env_clear(EnvObject *self)
      * This prevents any descendant from starting new LMDB operations. */
     INVALIDATE_MARK(self)
 
-    /* Wait for in-flight LMDB operations to complete.  active_ops is
-     * incremented/decremented under the GIL.  ACTIVE_OPS_DEC releases
-     * the lock when active_ops reaches 0, waking us.  Issue #180. */
+    /* Wait for in-flight LMDB operations to complete.  self->valid = 0
+     * above (GIL held) prevents new ones from starting.  Issue #180. */
     if(self->active_ops > 0) {
-        self->active_ops_waiter = 1;
-        Py_BEGIN_ALLOW_THREADS
-        PyThread_acquire_lock(self->active_ops_lock, WAIT_LOCK);
-        Py_END_ALLOW_THREADS
-        /* Re-acquire so lock stays in locked state for next wait. */
-        PyThread_acquire_lock(self->active_ops_lock, NOWAIT_LOCK);
+        ENV_WAIT_WHILE(self, self->active_ops > 0);
     }
 
     /* LMDB requires all transactions to be closed before mdb_env_close,
@@ -1483,18 +1521,14 @@ env_clear(EnvObject *self)
      * file underneath it strands a dangling entry on the owning thread's
      * robust list -> SIGSEGV in a later mdb_txn_begin on aarch64 (glibc
      * tolerates this on x86_64).  Honor the contract: block until the
-     * owning thread releases the write txn (it signals write_txn_lock
-     * after its abort/commit unlocks the mutex on the correct thread),
-     * then tear the mapping down.  We check write_txn_tid under the GIL
-     * and set the waiter flag before releasing it, so the owning thread
-     * (which needs the GIL to run its teardown) cannot signal before we
-     * are registered -- no lost wakeup, no polling.  Issue #465. */
-    if(self->write_txn_tid &&
-       self->write_txn_tid != (unsigned long) PyThread_get_thread_ident()) {
-        self->write_txn_waiter = 1;
-        Py_BEGIN_ALLOW_THREADS
-        PyThread_acquire_lock(self->write_txn_lock, WAIT_LOCK);
-        Py_END_ALLOW_THREADS
+     * owning thread releases the write txn, then tear the mapping down.
+     * The owning thread broadcasts on ops_cond after its abort/commit
+     * unlocks the mutex (CLEAR_WRITE_TXN_TID); the condition variable
+     * re-checks the predicate under ops_mutex, so there is no lost
+     * wakeup and no polling.  Issue #465. */
+    if(self->write_txn_tid && self->write_txn_tid != me) {
+        ENV_WAIT_WHILE(self,
+            self->write_txn_tid && self->write_txn_tid != me);
     }
 
     /* Phase 2: actual cleanup (may release GIL for txn_abort etc.) */
@@ -1524,7 +1558,7 @@ env_clear(EnvObject *self)
          * reference and freeing the EnvObject while mdb_env_close is
          * still running.  Issue #180, #418. */
         Py_INCREF((PyObject *)self);
-        self->active_ops++;
+        ACTIVE_OPS_INC(self);
         Py_BEGIN_ALLOW_THREADS
         mdb_env_close(env);
         Py_END_ALLOW_THREADS
@@ -1557,13 +1591,15 @@ env_dealloc(EnvObject *self)
      * env_clear drops it to 1, not 0. */
     Py_SET_REFCNT((PyObject *)self, 1);
     env_clear(self);
-    if(self->active_ops_lock) {
-        PyThread_free_lock(self->active_ops_lock);
-        self->active_ops_lock = NULL;
-    }
-    if(self->write_txn_lock) {
-        PyThread_free_lock(self->write_txn_lock);
-        self->write_txn_lock = NULL;
+    if(self->ops_sync_ready) {
+        self->ops_sync_ready = 0;
+#ifdef _WIN32
+        DeleteCriticalSection(&self->ops_mutex);
+        /* CONDITION_VARIABLEs need no explicit destruction. */
+#else
+        pthread_mutex_destroy(&self->ops_mutex);
+        pthread_cond_destroy(&self->ops_cond);
+#endif
     }
     PyObject_Del(self);
 }
@@ -1652,29 +1688,27 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->pid = _cached_pid;
     self->write_txn_tid = 0;
     self->active_ops = 0;
-    self->active_ops_waiter = 0;
-    self->write_txn_waiter = 0;
-    self->write_txn_lock = NULL;
     self->resizing = 0;
     self->resize_tid = 0;
-    self->active_ops_lock = PyThread_allocate_lock();
-    if(! self->active_ops_lock) {
-        PyErr_SetString(PyExc_MemoryError, "unable to allocate lock");
+    self->ops_sync_ready = 0;
+#ifdef _WIN32
+    InitializeCriticalSection(&self->ops_mutex);
+    InitializeConditionVariable(&self->ops_cond);
+#else
+    if(pthread_mutex_init(&self->ops_mutex, NULL)) {
+        PyErr_SetString(PyExc_MemoryError, "unable to initialize mutex");
         Py_DECREF(self);
         return NULL;
     }
-    /* Acquire immediately so waiters will block until signaled. */
-    PyThread_acquire_lock(self->active_ops_lock, NOWAIT_LOCK);
-
-    self->write_txn_lock = PyThread_allocate_lock();
-    if(! self->write_txn_lock) {
-        PyErr_SetString(PyExc_MemoryError, "unable to allocate lock");
+    if(pthread_cond_init(&self->ops_cond, NULL)) {
+        pthread_mutex_destroy(&self->ops_mutex);
+        PyErr_SetString(PyExc_MemoryError,
+                        "unable to initialize condition variable");
         Py_DECREF(self);
         return NULL;
     }
-    /* Acquire immediately so a close() waiter blocks until the owning
-     * thread releases its write transaction. */
-    PyThread_acquire_lock(self->write_txn_lock, NOWAIT_LOCK);
+#endif
+    self->ops_sync_ready = 1;
 
     if((rc = mdb_env_create(&self->env))) {
         err_set("mdb_env_create", rc);
@@ -2437,8 +2471,10 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
      * concurrently with the remap.  GIL-held LMDB calls need no gate —
      * the remap below also runs with the GIL held, so they cannot
      * overlap it.  Issue #475. */
+    ENV_SYNC_LOCK(self);
     self->resizing = 1;
     self->resize_tid = (unsigned long) PyThread_get_thread_ident();
+    ENV_SYNC_UNLOCK(self);
 
     /* Phase 1: quickly mark open transactions (and their cursors) invalid so
      * no new LMDB operations can start on them.  Database handles are left
@@ -2446,15 +2482,14 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
      * stays valid (we do NOT set self->valid = 0). */
     INVALIDATE_MARK_TXNS(self)
 
-    /* Wait for in-flight LMDB operations to complete, by polling.  The
-     * active_ops_waiter protocol is single-waiter: trans_abort (and
-     * env_clear) may be blocked in it concurrently — e.g. a write
-     * transaction abort waiting out a child operation, having already
-     * cleared write_txn_tid — and a second waiter on the same lock loses
-     * the wakeup and deadlocks.  Polling has no such collision, and a
-     * resize is rare and heavyweight anyway.  Issue #475. */
+    /* Wait for in-flight LMDB operations to complete.  The condition
+     * variable supports multiple waiters, so this cannot collide with a
+     * trans_abort or env_clear draining concurrently.  The outer loop
+     * re-checks under the GIL: trans_dealloc on another thread can
+     * increment active_ops (it does not pass the resize gate) between the
+     * wait ending and us reacquiring the GIL.  Issue #475. */
     while(self->active_ops > 0) {
-        MILLISLEEP();
+        ENV_WAIT_WHILE(self, self->active_ops > 0);
     }
 
     /* Phase 2: abort all child transactions and close cursors.  This must
@@ -2466,20 +2501,25 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
      * holding active_ops: trans_abort() NULLs self->txn on entry (so the
      * invalidation above skipped it) and may sit in its child-op wait
      * before performing the real mdb_txn_abort.  Such a transaction keeps
-     * write_txn_tid set until the abort completes, and either the tid is
-     * still set or its final abort/dealloc is in flight under active_ops —
-     * both observable here.  Wait them out, or the remap below would find
-     * the transaction undead and fail with EINVAL.  New write transactions
-     * cannot start: begins fail fast on the resize gate.  Issue #475. */
+     * write_txn_tid set until the abort completes (CLEAR_WRITE_TXN_TID
+     * broadcasts), and either the tid is still set or its final
+     * abort/dealloc is in flight under active_ops — both observable here.
+     * Wait them out, or the remap below would find the transaction undead
+     * and fail with EINVAL.  New write transactions cannot start: begins
+     * fail fast on the resize gate.  Issue #475. */
     while(self->active_ops > 0 || self->write_txn_tid) {
-        MILLISLEEP();
+        ENV_WAIT_WHILE(self,
+            self->active_ops > 0 || self->write_txn_tid);
     }
 
     /* A destructor triggered during invalidation may have closed the env
      * on this thread (same-thread re-entry passes the resize gate).
      * Don't remap a closed env. */
     if(! self->valid || ! self->env) {
+        ENV_SYNC_LOCK(self);
         self->resizing = 0;
+        ENV_SYNC_BROADCAST(self);
+        ENV_SYNC_UNLOCK(self);
         return err_invalid();
     }
 
@@ -2503,7 +2543,12 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
         self->valid = 0;
     }
 
+    /* Leave the critical section; wake an env_clear waiting for the
+     * resize to finish. */
+    ENV_SYNC_LOCK(self);
     self->resizing = 0;
+    ENV_SYNC_BROADCAST(self);
+    ENV_SYNC_UNLOCK(self);
 
     if(rc) {
         return err_set("mdb_env_set_mapsize", rc);
@@ -2714,7 +2759,7 @@ _cursor_get_c(CursorObject *self, enum MDB_cursor_op op)
 {
     int rc;
 
-    self->trans->env->active_ops++;
+    ACTIVE_OPS_INC(self->trans->env);
     Py_BEGIN_ALLOW_THREADS;
     rc = mdb_cursor_get(self->curs, &self->key, &self->val, op);
     Py_END_ALLOW_THREADS;
@@ -4084,7 +4129,10 @@ trans_clear(TransObject *self)
         self->txn = NULL;  /* Prevent double-abort from concurrent
                             * trans_clear calls (issue #180). */
         if(self->env && !(self->flags & TRANS_RDONLY)) {
-            self->env->write_txn_tid = 0;
+            /* The abort below runs with the GIL held, so a #465 waiter
+             * (which needs the GIL to proceed) cannot act on the cleared
+             * tid before the write mutex is actually released. */
+            CLEAR_WRITE_TXN_TID(self->env);
         }
         /* Don't release the GIL here — trans_clear is called from
          * invalidate() while iterating the children list, and releasing
@@ -4142,15 +4190,16 @@ trans_dealloc(TransObject *self)
              * this abort is in flight.  Issue #180. */
             self->txn = NULL;
             if(self->env) {
-                self->env->write_txn_tid = 0;
                 if(self->env->env) {
-                    self->env->active_ops++;
+                    ACTIVE_OPS_INC(self->env);
                     txn_abort(txn);
                     ACTIVE_OPS_DEC(self->env);
-                    /* Mutex released on this (owning) thread; wake a
-                     * close() blocked waiting for it.  Issue #465. */
-                    NOTIFY_WRITE_TXN_DONE(self->env);
                 }
+                /* Mutex released on this (owning) thread; wakes a
+                 * close() blocked waiting for it.  Cleared after the
+                 * abort so waiters never observe tid == 0 while the
+                 * transaction is still live.  Issues #465, #475. */
+                CLEAR_WRITE_TXN_TID(self->env);
             }
         }
         MDEBUG("deleting trans")
@@ -4244,27 +4293,22 @@ trans_abort(TransObject *self, PyObject *Py_UNUSED(ignored))
                  * invalidation pass skips this txn because self->txn was
                  * already NULLed above).  Issues #465, #475. */
                 if(env->active_ops > 0) {
-                    env->active_ops_waiter = 1;
-                    Py_BEGIN_ALLOW_THREADS
-                    PyThread_acquire_lock(env->active_ops_lock, WAIT_LOCK);
-                    Py_END_ALLOW_THREADS
-                    PyThread_acquire_lock(env->active_ops_lock, NOWAIT_LOCK);
+                    ENV_WAIT_WHILE(env, env->active_ops > 0);
                 }
-                env->active_ops++;
+                ACTIVE_OPS_INC(env);
                 Py_BEGIN_ALLOW_THREADS
                 mdb_txn_abort(txn);
                 Py_END_ALLOW_THREADS
                 ACTIVE_OPS_DEC(env);
-                env->write_txn_tid = 0;
-                /* Mutex released on this (owning) thread; wake a close()
+                /* Mutex released on this (owning) thread; wakes a close()
                  * blocked waiting for it.  Issue #465. */
-                NOTIFY_WRITE_TXN_DONE(env);
+                CLEAR_WRITE_TXN_TID(env);
             } else {
                 if(txn) {
                     mdb_txn_abort(txn);
                 }
                 if(env) {
-                    env->write_txn_tid = 0;
+                    CLEAR_WRITE_TXN_TID(env);
                 }
             }
         }
@@ -4305,16 +4349,17 @@ trans_commit(TransObject *self, PyObject *Py_UNUSED(ignored))
         EnvObject *env = self->env;
         self->txn = NULL;
         Py_INCREF((PyObject *) env);
-        env->write_txn_tid = 0;
         DEBUG("committing")
-        env->active_ops++;
+        ACTIVE_OPS_INC(env);
         Py_BEGIN_ALLOW_THREADS
         rc = mdb_txn_commit(txn);
         Py_END_ALLOW_THREADS
         ACTIVE_OPS_DEC(env);
-        /* Mutex released on this (owning) thread; wake a close() blocked
-         * waiting for it.  Issue #465. */
-        NOTIFY_WRITE_TXN_DONE(env);
+        /* Mutex released on this (owning) thread; wakes a close() blocked
+         * waiting for it.  Cleared after the commit so waiters never
+         * observe tid == 0 while the transaction is still live.
+         * Issues #465, #475. */
+        CLEAR_WRITE_TXN_TID(env);
         Py_DECREF((PyObject *) env);
         if(rc) {
             return err_set("mdb_txn_commit", rc);
@@ -4460,7 +4505,7 @@ trans_get(TransObject *self, PyObject *args, PyObject *kwds)
         goto out;
     }
 
-    self->env->active_ops++;
+    ACTIVE_OPS_INC(self->env);
     Py_BEGIN_ALLOW_THREADS
     rc = mdb_get(self->txn, arg.db->dbi, &arg.key, &val);
     preload(rc, val.mv_data, val.mv_size);

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -57,6 +57,22 @@
 #include <pthread.h>
 #endif
 
+/* Sequentially-consistent atomic counter primitives.  INCR/DECR return the
+ * new value.  seq_cst keeps the waiter-registration protocol (see
+ * ACTIVE_OPS_DEC / ENV_WAIT_WHILE) simple to reason about, and costs the
+ * same as acq_rel on x86 for the RMW operations. */
+#ifdef _WIN32
+typedef volatile LONG lmdb_atomic_t;
+#define LMDB_ATOMIC_INCR(p) InterlockedIncrement(p)
+#define LMDB_ATOMIC_DECR(p) InterlockedDecrement(p)
+#define LMDB_ATOMIC_LOAD(p) InterlockedCompareExchange((p), 0, 0)
+#else
+typedef int lmdb_atomic_t;
+#define LMDB_ATOMIC_INCR(p) __atomic_add_fetch((p), 1, __ATOMIC_SEQ_CST)
+#define LMDB_ATOMIC_DECR(p) __atomic_sub_fetch((p), 1, __ATOMIC_SEQ_CST)
+#define LMDB_ATOMIC_LOAD(p) __atomic_load_n((p), __ATOMIC_SEQ_CST)
+#endif
+
 #include "lmdb.h"
 #include "preload.h"
 
@@ -194,8 +210,15 @@ struct EnvObject {
     PyObject *open_path;
     /** Count of in-flight LMDB operations (GIL released).  env_clear and
      *  set_mapsize wait for this to reach 0 before closing/remapping the
-     *  env.  Issue #180. */
-    int active_ops;
+     *  env.  Modified with atomics (LMDB_ATOMIC_*) — the inc/dec is on
+     *  the per-operation hot path, so it must not take ops_mutex.
+     *  Issue #180. */
+    lmdb_atomic_t active_ops;
+    /** Count of threads inside ENV_WAIT_WHILE.  Registered under
+     *  ops_mutex before the predicate check; read lock-free by
+     *  ACTIVE_OPS_DEC to skip the broadcast when nobody is draining
+     *  (the common case). */
+    lmdb_atomic_t ops_waiters;
     /** 1 while set_mapsize() is inside its invalidate/remap critical
      *  section.  New GIL-releasing LMDB operations fail fast with EINVAL
      *  until the resize completes (see ENV_RESIZE_BLOCKED).  Issue #475. */
@@ -788,40 +811,51 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
 #endif
 
 /* ENV_WAIT_WHILE: block (GIL released) until `cond` becomes false.  `cond`
- * is evaluated under ops_mutex, so it may only reference fields whose
- * writes take the mutex (active_ops, write_txn_tid, resizing/resize_tid)
- * and thread-locals.  Multiple threads may wait concurrently; every state
- * change broadcasts.  On return the GIL has been reacquired, and GIL-
- * guarded state may have changed meanwhile — callers needing a GIL-stable
- * predicate must re-check and loop.  Issues #180, #465, #475. */
+ * is evaluated under ops_mutex, so it may only reference thread-locals,
+ * fields whose writes take the mutex (write_txn_tid, resizing/resize_tid),
+ * and atomics read via LMDB_ATOMIC_LOAD (active_ops).  Multiple threads
+ * may wait concurrently; every state change wakes them.  The waiter is
+ * counted in ops_waiters BEFORE the predicate check: ACTIVE_OPS_DEC reads
+ * the count lock-free after its decrement, so (both accesses being
+ * seq_cst) either this thread's check observes the count already at 0 and
+ * never sleeps, or the decrementer observes our registration and
+ * broadcasts — and since the broadcast is taken under ops_mutex, it
+ * cannot slip between our check and the wait.  No lost wakeup.  On return
+ * the GIL has been reacquired, and GIL-guarded state may have changed
+ * meanwhile — callers needing a GIL-stable predicate must re-check and
+ * loop.  Issues #180, #465, #475. */
 #define ENV_WAIT_WHILE(_env, cond) \
     do { \
         Py_BEGIN_ALLOW_THREADS \
         ENV_SYNC_LOCK(_env); \
+        LMDB_ATOMIC_INCR(&(_env)->ops_waiters); \
         while(cond) { \
             ENV_SYNC_WAIT(_env); \
         } \
+        LMDB_ATOMIC_DECR(&(_env)->ops_waiters); \
         ENV_SYNC_UNLOCK(_env); \
         Py_END_ALLOW_THREADS \
     } while(0)
 
-/* ACTIVE_OPS_INC/DEC: adjust the in-flight operation count.  Must be
- * called with the GIL held; the mutex makes the update visible to
- * non-GIL-holding waiters in ENV_WAIT_WHILE.  Issue #180. */
+/* ACTIVE_OPS_INC/DEC: adjust the in-flight operation count.  This is the
+ * per-operation hot path (twice per cursor step), so it is lock-free: a
+ * single atomic RMW, plus — only on the 0-crossing — a lock-free read of
+ * ops_waiters to decide whether any drainer needs waking.  The mutex is
+ * taken only to deliver that (rare) broadcast, so a waiter between its
+ * predicate check and its wait cannot miss it.  Issues #180, #475. */
 #define ACTIVE_OPS_INC(_env) \
     do { \
-        ENV_SYNC_LOCK(_env); \
-        (_env)->active_ops++; \
-        ENV_SYNC_UNLOCK(_env); \
+        LMDB_ATOMIC_INCR(&(_env)->active_ops); \
     } while(0)
 
 #define ACTIVE_OPS_DEC(_env) \
     do { \
-        ENV_SYNC_LOCK(_env); \
-        if(--(_env)->active_ops == 0) { \
+        if(LMDB_ATOMIC_DECR(&(_env)->active_ops) == 0 && \
+           LMDB_ATOMIC_LOAD(&(_env)->ops_waiters) != 0) { \
+            ENV_SYNC_LOCK(_env); \
             ENV_SYNC_BROADCAST(_env); \
+            ENV_SYNC_UNLOCK(_env); \
         } \
-        ENV_SYNC_UNLOCK(_env); \
     } while(0)
 
 /* CLEAR_WRITE_TXN_TID: record that this thread's write transaction is
@@ -1505,8 +1539,8 @@ env_clear(EnvObject *self)
 
     /* Wait for in-flight LMDB operations to complete.  self->valid = 0
      * above (GIL held) prevents new ones from starting.  Issue #180. */
-    if(self->active_ops > 0) {
-        ENV_WAIT_WHILE(self, self->active_ops > 0);
+    if(LMDB_ATOMIC_LOAD(&self->active_ops) > 0) {
+        ENV_WAIT_WHILE(self, LMDB_ATOMIC_LOAD(&self->active_ops) > 0);
     }
 
     /* LMDB requires all transactions to be closed before mdb_env_close,
@@ -1688,6 +1722,7 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->pid = _cached_pid;
     self->write_txn_tid = 0;
     self->active_ops = 0;
+    self->ops_waiters = 0;
     self->resizing = 0;
     self->resize_tid = 0;
     self->ops_sync_ready = 0;
@@ -2488,8 +2523,8 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
      * re-checks under the GIL: trans_dealloc on another thread can
      * increment active_ops (it does not pass the resize gate) between the
      * wait ending and us reacquiring the GIL.  Issue #475. */
-    while(self->active_ops > 0) {
-        ENV_WAIT_WHILE(self, self->active_ops > 0);
+    while(LMDB_ATOMIC_LOAD(&self->active_ops) > 0) {
+        ENV_WAIT_WHILE(self, LMDB_ATOMIC_LOAD(&self->active_ops) > 0);
     }
 
     /* Phase 2: abort all child transactions and close cursors.  This must
@@ -2507,9 +2542,9 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
      * Wait them out, or the remap below would find the transaction undead
      * and fail with EINVAL.  New write transactions cannot start: begins
      * fail fast on the resize gate.  Issue #475. */
-    while(self->active_ops > 0 || self->write_txn_tid) {
+    while(LMDB_ATOMIC_LOAD(&self->active_ops) > 0 || self->write_txn_tid) {
         ENV_WAIT_WHILE(self,
-            self->active_ops > 0 || self->write_txn_tid);
+            LMDB_ATOMIC_LOAD(&self->active_ops) > 0 || self->write_txn_tid);
     }
 
     /* A destructor triggered during invalidation may have closed the env
@@ -4292,8 +4327,8 @@ trans_abort(TransObject *self, PyObject *Py_UNUSED(ignored))
                  * check and then find the txn undead at remap time (its
                  * invalidation pass skips this txn because self->txn was
                  * already NULLed above).  Issues #465, #475. */
-                if(env->active_ops > 0) {
-                    ENV_WAIT_WHILE(env, env->active_ops > 0);
+                if(LMDB_ATOMIC_LOAD(&env->active_ops) > 0) {
+                    ENV_WAIT_WHILE(env, LMDB_ATOMIC_LOAD(&env->active_ops) > 0);
                 }
                 ACTIVE_OPS_INC(env);
                 Py_BEGIN_ALLOW_THREADS

--- a/lmdb/cpython.c
+++ b/lmdb/cpython.c
@@ -55,6 +55,7 @@
 
 #ifndef _WIN32
 #include <pthread.h>
+#include <unistd.h> /* usleep */
 #endif
 
 #include "lmdb.h"
@@ -209,6 +210,14 @@ struct EnvObject {
     PyThread_type_lock write_txn_lock;
     /** 1 if a thread is blocked in close() waiting for the write txn. */
     int write_txn_waiter;
+    /** 1 while set_mapsize() is inside its invalidate/remap critical
+     *  section.  New GIL-releasing LMDB operations fail fast with EINVAL
+     *  until the resize completes (see ENV_RESIZE_BLOCKED).  Issue #475. */
+    int resizing;
+    /** Thread ID of the thread performing the resize, so same-thread
+     *  re-entry (e.g. a destructor running during invalidation, while the
+     *  old map is still valid) passes through instead of failing. */
+    unsigned long resize_tid;
 };
 
 /** TransObject.flags bitfield values. */
@@ -787,14 +796,50 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
  * chains like self->trans->env remain valid for ACTIVE_OPS_DEC even if
  * another thread NULLs an intermediate pointer during the GIL release.
  * Issue #180. */
+/* MILLISLEEP: sleep ~1ms with the GIL released; used by polling waits. */
+#ifdef _WIN32
+#define MILLISLEEP() \
+    do { \
+        Py_BEGIN_ALLOW_THREADS \
+        Sleep(1); \
+        Py_END_ALLOW_THREADS \
+    } while(0)
+#else
+#define MILLISLEEP() \
+    do { \
+        Py_BEGIN_ALLOW_THREADS \
+        usleep(1000); \
+        Py_END_ALLOW_THREADS \
+    } while(0)
+#endif
+
+/* ENV_RESIZE_BLOCKED: true when another thread is inside set_mapsize()'s
+ * invalidate/remap critical section.  A new GIL-releasing LMDB operation
+ * must not start then: the remap invalidates in-flight pointers, and any
+ * txn/cursor arguments the operation captured were (or are about to be)
+ * invalidated by the resize.  The operation fails fast with EINVAL instead
+ * of blocking — its handles are dead either way, and failing under the GIL
+ * (set_mapsize sets `resizing` under the GIL too) needs no lock protocol.
+ * Same-thread re-entry (a destructor invoked during the resize's
+ * invalidation phase, while the old map is still valid) passes through.
+ * Issue #475. */
+#define ENV_RESIZE_BLOCKED(_env) \
+    ((_env)->resizing && \
+     (_env)->resize_tid != (unsigned long) PyThread_get_thread_ident())
+
 #define ENV_UNLOCKED(_env, out, e) \
     do { \
         EnvObject *_saved_env = (_env); \
-        _saved_env->active_ops++; \
-        Py_BEGIN_ALLOW_THREADS \
-        out = (e); \
-        Py_END_ALLOW_THREADS \
-        ACTIVE_OPS_DEC(_saved_env); \
+        if(ENV_RESIZE_BLOCKED(_saved_env)) { \
+            out = EINVAL; \
+        } \
+        else { \
+            _saved_env->active_ops++; \
+            Py_BEGIN_ALLOW_THREADS \
+            out = (e); \
+            Py_END_ALLOW_THREADS \
+            ACTIVE_OPS_DEC(_saved_env); \
+        } \
     } while(0)
 
 #define PRELOAD_UNLOCKED(_rc, _data, _size) \
@@ -802,14 +847,22 @@ val_from_buffer(MDB_val *val, PyObject *buf, BufViewList *bvl)
     preload(_rc, _data, _size); \
     Py_END_ALLOW_THREADS
 
+/* ENV_PRELOAD_UNLOCKED: preload faults data pages in with the GIL released.
+ * If a resize is pending, skip it WITHOUT releasing the GIL: _data points
+ * into the current map, and the caller's subsequent GIL-held copies from it
+ * are only safe as long as the resize thread (which needs the GIL for its
+ * remap) cannot run.  preload is purely an optimization, so skipping is
+ * always correct.  Issue #475. */
 #define ENV_PRELOAD_UNLOCKED(_env, _rc, _data, _size) \
     do { \
         EnvObject *_saved_env = (_env); \
-        _saved_env->active_ops++; \
-        Py_BEGIN_ALLOW_THREADS \
-        preload(_rc, _data, _size); \
-        Py_END_ALLOW_THREADS \
-        ACTIVE_OPS_DEC(_saved_env); \
+        if(! _saved_env->resizing) { \
+            _saved_env->active_ops++; \
+            Py_BEGIN_ALLOW_THREADS \
+            preload(_rc, _data, _size); \
+            Py_END_ALLOW_THREADS \
+            ACTIVE_OPS_DEC(_saved_env); \
+        } \
     } while(0)
 
 /* ---------------- */
@@ -1078,6 +1131,14 @@ make_trans(EnvObject *env, DbObject *db, TransObject *parent, int write,
         return err_set(msg, EACCES);
     }
 
+    /* Fail fast while another thread is inside set_mapsize's critical
+     * section: a txn begun now would reference the map about to be
+     * unmapped.  The GIL-held read path needs this explicit check; the
+     * write path would be caught by ENV_UNLOCKED anyway.  Issue #475. */
+    if(ENV_RESIZE_BLOCKED(env)) {
+        return err_set("mdb_txn_begin", EINVAL);
+    }
+
     if(write && !parent &&
        env->write_txn_tid == PyThread_get_thread_ident()) {
         const char *msg =
@@ -1251,6 +1312,13 @@ txn_db_from_name(EnvObject *env, const char *name,
     DbObject *dbo;
 
     int begin_flags = (name == NULL || env->readonly) ? MDB_RDONLY : 0;
+
+    /* Fail fast while another thread is remapping (issue #475); the txn
+     * begun below would reference the map being replaced. */
+    if(ENV_RESIZE_BLOCKED(env)) {
+        err_set("mdb_txn_begin", EINVAL);
+        return NULL;
+    }
     /* Hold GIL: see make_trans comment and issue #180. */
     rc = mdb_txn_begin(env->env, NULL, begin_flags, &txn);
     if(rc) {
@@ -1375,6 +1443,16 @@ env_clear(EnvObject *self)
     MDB_txn * txn;
 
     MDEBUG("env_clear")
+
+    /* If another thread is inside set_mapsize's critical section, wait
+     * (by polling — the active_ops waiter protocol is single-waiter) for
+     * it to finish before tearing the env down, so the two invalidation
+     * walks cannot interleave.  Same-thread re-entry (a destructor during
+     * the resize's invalidation phase) passes through.  set_mapsize never
+     * waits on close, so this cannot deadlock.  Issue #475. */
+    while(ENV_RESIZE_BLOCKED(self)) {
+        MILLISLEEP();
+    }
 
     self->valid = 0;
     /* Phase 1: quickly mark all descendants invalid (no I/O, GIL held).
@@ -1577,6 +1655,8 @@ env_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self->active_ops_waiter = 0;
     self->write_txn_waiter = 0;
     self->write_txn_lock = NULL;
+    self->resizing = 0;
+    self->resize_tid = 0;
     self->active_ops_lock = PyThread_allocate_lock();
     if(! self->active_ops_lock) {
         PyErr_SetString(PyExc_MemoryError, "unable to allocate lock");
@@ -2342,26 +2422,66 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
         return NULL;
     }
 
+    /* Reject overlapping resizes.  Cannot be our own thread (no Python runs
+     * between the flag being set and cleared except destructors during
+     * invalidation, and re-entering set_mapsize from one is degenerate). */
+    if(self->resizing) {
+        PyErr_Format(Error,
+            "Cannot set_mapsize: another set_mapsize is in progress");
+        return NULL;
+    }
+
+    /* Enter the resize critical section: from here until the flag is
+     * cleared, new GIL-releasing LMDB operations on this env fail fast
+     * with EINVAL (see ENV_RESIZE_BLOCKED), so nothing new can run
+     * concurrently with the remap.  GIL-held LMDB calls need no gate —
+     * the remap below also runs with the GIL held, so they cannot
+     * overlap it.  Issue #475. */
+    self->resizing = 1;
+    self->resize_tid = (unsigned long) PyThread_get_thread_ident();
+
     /* Phase 1: quickly mark open transactions (and their cursors) invalid so
      * no new LMDB operations can start on them.  Database handles are left
      * valid — their MDB_dbi survives the remap (issue #475).  The env itself
      * stays valid (we do NOT set self->valid = 0). */
     INVALIDATE_MARK_TXNS(self)
 
-    /* Wait for in-flight LMDB operations to complete.  Same pattern as
-     * env_clear — see issue #180. */
-    if(self->active_ops > 0) {
-        self->active_ops_waiter = 1;
-        Py_BEGIN_ALLOW_THREADS
-        PyThread_acquire_lock(self->active_ops_lock, WAIT_LOCK);
-        Py_END_ALLOW_THREADS
-        PyThread_acquire_lock(self->active_ops_lock, NOWAIT_LOCK);
+    /* Wait for in-flight LMDB operations to complete, by polling.  The
+     * active_ops_waiter protocol is single-waiter: trans_abort (and
+     * env_clear) may be blocked in it concurrently — e.g. a write
+     * transaction abort waiting out a child operation, having already
+     * cleared write_txn_tid — and a second waiter on the same lock loses
+     * the wakeup and deadlocks.  Polling has no such collision, and a
+     * resize is rare and heavyweight anyway.  Issue #475. */
+    while(self->active_ops > 0) {
+        MILLISLEEP();
     }
 
     /* Phase 2: abort all child transactions and close cursors.  This must
      * happen while the old mmap is still valid so mdb_txn_abort can
      * safely touch the pages it needs to.  Database handles are preserved. */
     INVALIDATE_TXNS(self)
+
+    /* A write transaction may still be dying on another thread without
+     * holding active_ops: trans_abort() NULLs self->txn on entry (so the
+     * invalidation above skipped it) and may sit in its child-op wait
+     * before performing the real mdb_txn_abort.  Such a transaction keeps
+     * write_txn_tid set until the abort completes, and either the tid is
+     * still set or its final abort/dealloc is in flight under active_ops —
+     * both observable here.  Wait them out, or the remap below would find
+     * the transaction undead and fail with EINVAL.  New write transactions
+     * cannot start: begins fail fast on the resize gate.  Issue #475. */
+    while(self->active_ops > 0 || self->write_txn_tid) {
+        MILLISLEEP();
+    }
+
+    /* A destructor triggered during invalidation may have closed the env
+     * on this thread (same-thread re-entry passes the resize gate).
+     * Don't remap a closed env. */
+    if(! self->valid || ! self->env) {
+        self->resizing = 0;
+        return err_invalid();
+    }
 
     /* Abort the spare read-only transaction — it holds references to the
      * old memory map. */
@@ -2371,12 +2491,21 @@ env_reader_set_mapsize(EnvObject *self, PyObject *args, PyObject *kwargs)
         mdb_txn_abort(txn);
     }
 
-    /* Now safe to remap. */
+    /* Now safe to remap: in-flight operations have drained, new ones fail
+     * fast on the resize gate, and this call itself runs with the GIL
+     * held. */
     rc = mdb_env_set_mapsize(self->env, arg.map_size);
+
     if(rc) {
         /* Remap failed — env is in an unusable state.  Mark it invalid
-         * so subsequent operations raise a clear error. */
+         * (BEFORE clearing the gate, so operations observe it and bail
+         * out instead of calling into the unusable env). */
         self->valid = 0;
+    }
+
+    self->resizing = 0;
+
+    if(rc) {
         return err_set("mdb_env_set_mapsize", rc);
     }
 
@@ -4101,14 +4230,19 @@ trans_abort(TransObject *self, PyObject *Py_UNUSED(ignored))
             }
             self->flags |= TRANS_SPARE;
         } else {
-            if(env) {
-                env->write_txn_tid = 0;
-            }
             if(txn && env) {
                 DEBUG("aborting")
                 /* Wait for child ops (e.g. child commit) to finish before
                  * aborting, since LMDB doesn't allow concurrent access to
-                 * parent+child txns.  Issue #180. */
+                 * parent+child txns.  Issue #180.
+                 *
+                 * write_txn_tid stays set until the abort completes: the
+                 * waits below release the GIL while the MDB txn (and the
+                 * writer mutex) is still live, and clearing the tid early
+                 * would let a concurrent set_mapsize() pass its write-txn
+                 * check and then find the txn undead at remap time (its
+                 * invalidation pass skips this txn because self->txn was
+                 * already NULLed above).  Issues #465, #475. */
                 if(env->active_ops > 0) {
                     env->active_ops_waiter = 1;
                     Py_BEGIN_ALLOW_THREADS
@@ -4121,11 +4255,17 @@ trans_abort(TransObject *self, PyObject *Py_UNUSED(ignored))
                 mdb_txn_abort(txn);
                 Py_END_ALLOW_THREADS
                 ACTIVE_OPS_DEC(env);
+                env->write_txn_tid = 0;
                 /* Mutex released on this (owning) thread; wake a close()
                  * blocked waiting for it.  Issue #465. */
                 NOTIFY_WRITE_TXN_DONE(env);
-            } else if(txn) {
-                mdb_txn_abort(txn);
+            } else {
+                if(txn) {
+                    mdb_txn_abort(txn);
+                }
+                if(env) {
+                    env->write_txn_tid = 0;
+                }
             }
         }
         Py_XDECREF((PyObject *) env);

--- a/tests/env_test.py
+++ b/tests/env_test.py
@@ -388,6 +388,106 @@ class SetMapSizeTest(unittest.TestCase):
                 assert txn.get(str(i).encode()) == b'word'
 
 
+class SetMapSizeConcurrencyTest(unittest.TestCase):
+    """Stress set_mapsize() against concurrent environment operations.
+
+    set_mapsize's invalidate/remap critical section must exclude new LMDB
+    operations (they block until the resize completes) while draining
+    in-flight ones.  Concurrent operations may observe an invalidated
+    transaction (lmdb.Error) but must never crash, corrupt, or deadlock.
+    Issue #475."""
+
+    DURATION = 2.0
+
+    def tearDown(self):
+        testlib.cleanup()
+
+    def test_resize_vs_ops_stress(self):
+        import threading
+        import time
+
+        _, env = testlib.temp_env(map_size=PAGE_SIZE * 64)
+        with env.begin(write=True) as txn:
+            for i in range(512):
+                txn.put(str(i).encode(), b'x' * 64)
+
+        stop = threading.Event()
+        failures = []
+
+        def tolerated(e):
+            """A handle invalidated by a concurrent resize surfaces as
+            lmdb.Error (CPython backend) or as a TypeError mentioning the
+            _invalid sentinel (CFFI backend)."""
+            return (isinstance(e, lmdb.Error) or
+                    (isinstance(e, TypeError) and
+                     '_LMDB_Resource' in str(e)))
+
+        def worker_read():
+            while not stop.is_set():
+                try:
+                    with env.begin() as txn:
+                        txn.get(b'1')
+                except Exception as e:
+                    if not tolerated(e):
+                        failures.append(e)
+                        return
+
+        def worker_env_ops():
+            while not stop.is_set():
+                try:
+                    env.stat()
+                    env.info()
+                except Exception as e:
+                    if not tolerated(e):
+                        failures.append(e)
+                        return
+
+        def worker_write():
+            while not stop.is_set():
+                try:
+                    with env.begin(write=True) as txn:
+                        txn.put(b'wkey', b'wval')
+                except Exception as e:
+                    if not tolerated(e):
+                        failures.append(e)
+                        return
+
+        threads = [threading.Thread(target=t) for t in
+                   (worker_read, worker_read, worker_env_ops, worker_write)]
+        for t in threads:
+            t.start()
+
+        size = PAGE_SIZE * 64
+        deadline = time.time() + self.DURATION
+        resizes = 0
+        try:
+            while time.time() < deadline:
+                size += PAGE_SIZE * 8
+                try:
+                    env.set_mapsize(size)
+                    resizes += 1
+                except lmdb.Error:
+                    # A write txn was active, or another resize raced us.
+                    pass
+        finally:
+            stop.set()
+            for t in threads:
+                # A generous timeout: a deadlocked gate shows up here.
+                t.join(timeout=30)
+
+        for t in threads:
+            self.assertFalse(t.is_alive(), "worker deadlocked")
+        self.assertEqual(failures, [])
+        self.assertGreater(resizes, 0)
+
+        # Environment remains fully usable afterward.
+        with env.begin(write=True) as txn:
+            txn.put(b'after', b'ok')
+        with env.begin() as txn:
+            assert txn.get(b'after') == b'ok'
+            assert txn.get(b'1') == b'x' * 64
+
+
 class CloseTest(unittest.TestCase):
     def tearDown(self):
         testlib.cleanup()


### PR DESCRIPTION
## Summary

Follow-up to #477 (issue #475). Fixes the race window where an LMDB operation starting on another thread during `set_mapsize()`'s invalidate/remap critical section could run concurrently with the `munmap`/`mmap` and touch the old mapping. While stress-testing the fix, three more bugs in the same neighborhood fell out — two of them deadlocks, one a crash — all fixed here and all covered by a new stress test.

## The original race (CPython backend)

`set_mapsize()` drains in-flight operations via `active_ops`, but a new operation could pass its validity check and enter its LMDB call in the window while the resize thread was blocked draining. The remap then ran concurrently with that call — use-after-free of the old map.

**Fix:** a resize gate (`env->resizing` + `resize_tid`). GIL-releasing LMDB calls (`ENV_UNLOCKED`) and transaction begins **fail fast with `EINVAL`** (an `lmdb.Error`) while another thread is mid-resize, rather than racing it. The flag is read and written under the GIL, so no lock protocol is involved. Same-thread re-entry (destructors running during invalidation, while the old map is still valid) passes through. `preload` is skipped without releasing the GIL while a resize is pending, so the caller's GIL-held value copies complete before the remap can run.

Failing fast (rather than blocking) is deliberate: a blocked-then-resumed operation would evaluate `self->txn`/`self->curs` *after* the resize NULLed them (`mdb_put(NULL, …)` segfault), and callers must already handle invalidation errors around `set_mapsize`.

## What the stress test then uncovered

1. **Deadlock — the `active_ops_waiter` protocol was single-waiter.** `trans_abort()` (waiting out a child operation, having already cleared `write_txn_tid`) and `set_mapsize()`'s drain could both register as waiters on `active_ops_lock`; the flag is a single int, one wakeup is delivered, the loser blocks forever. Reproduced ~100% by the stress test. Fixed at the root: the single-slot `PyThread` lock handoffs (`active_ops_lock`/`active_ops_waiter` and the #465 `write_txn_lock`/`write_txn_waiter`) are replaced with one `ops_mutex` + `ops_cond` condition variable (pthread on POSIX, `CRITICAL_SECTION`/`CONDITION_VARIABLE` on Windows). All waiters — `env_clear`'s drain, its #465 write-txn wait and wait-for-resize, `trans_abort`'s child-op wait, and `set_mapsize`'s drains — re-check their predicate under the mutex, any number can block concurrently, and every state change broadcasts. No lost wakeups, no polling.

2. **Resize failing and bricking the env — write txn "undead" at remap.** `trans_abort()` cleared `write_txn_tid` *before* its child-op wait and before actually calling `mdb_txn_abort` — and it NULLs `self->txn` on entry, so the resize's invalidation pass skips the txn (double-abort guard). `mdb_env_set_mapsize` then found `me_txn` set → `EINVAL` → env marked invalid. `trans_abort` now clears the tid only after the abort completes (also more accurate for `close()`'s #465 wait), and `set_mapsize` additionally waits until both `active_ops == 0` **and** `write_txn_tid == 0` after invalidation.

3. **CFFI: segfault + orphaned-tid deadlock.** 
   - `Transaction.get/put/delete/stat/drop/id` and `Environment.stat/info/sync/copy/copyfd/readers/reader_check` called into LMDB **without `_close_lock`** (cursor ops take it), so they raced both `set_mapsize()` and `close()` teardown — the stress test segfaulted PyPy on unmodified locking. All now serialize on `_close_lock`, consistent with the cursor ops.
   - `set_mapsize`'s write-txn check ran *outside* `_close_lock`; a write-txn begin (which holds the lock) could complete right after the check. Invalidating that txn orphaned `_write_txn_tid` — the owner's `abort()` sees `_txn` falsy and returns without clearing it — deadlocking a later `close()` in its #465 wait. The check is now re-done under the lock.

## Semantics

Operations racing a `set_mapsize()` on another thread now raise a transient `lmdb.Error` (CPython) or the CFFI invalid-handle `TypeError` instead of crashing/deadlocking. This is the same error class callers already handle for invalidated transactions around a resize; retry after the resize completes.

## Performance

The `active_ops` inc/dec is the per-operation hot path (twice per cursor step), so it stays lock-free: a seq_cst atomic RMW (`__atomic` builtins / `Interlocked*`), with the mutex touched only on the 0-crossing *and* only when a drainer is registered in the new `ops_waiters` counter. Waiters register under the mutex before checking their predicate, so either they observe the count at 0 and never sleep, or the decrementer observes the registration and broadcasts — no lost wakeup, no per-op mutex.

Microbenchmarks (CPython backend, minimal fully-cached ops, 64-byte values, interleaved master/branch rounds): `get`/`put`/cursor-iteration are **at parity with master** — cursor scan of 50k entries: branch minimum ≤ master's in all 4 rounds (~112–127 ns/op both). An earlier revision that took the mutex per op cost ~+11% on cursor iteration; the atomics remove that.

CFFI backend: `Transaction.get/put` gain an RLock acquire (~+10 ns/op on PyPy tight loops; cursor ops already took it), and `env.copy()`/`copyfd()` now hold `_close_lock` for the copy's duration, so a long copy blocks other LMDB calls on that env — the cost of closing its crash race. The CPython backend's `copy` is unaffected (still concurrent under `active_ops`).

## Tests

New `SetMapSizeConcurrencyTest` stress test (2 s: resize loop vs. 2 readers + env-ops + writer threads) on both backends. Before these fixes it deadlocked the CPython backend reliably and segfaulted PyPy; now:

- CPython: 25+ consecutive stress runs clean; full suite 371 passed.
- PyPy/CFFI: 6+ consecutive stress runs clean; full suite passes (the only error is the pre-existing `mdb_layout_test` import failure — pytest not installed in the PyPy venv).

